### PR TITLE
[#9][FEATURE] Modal Portal 설정 및 Modal 컴포넌트 생성

### DIFF
--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+
+interface IModal {
+  onClose: () => void;
+}
+
+export default function Modal({ onClose }: IModal) {
+  const handleBackgroundClick = (event: React.MouseEvent<HTMLElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <SModalWrapper onClick={handleBackgroundClick}>
+      <SModalContent>
+        <div>모달 내용이 들어갑니다.</div>
+        <SCloseBtn type="button" onClick={onClose}>
+          닫기
+        </SCloseBtn>
+      </SModalContent>
+    </SModalWrapper>
+  );
+}
+const SModalWrapper = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.3);
+`;
+
+const SModalContent = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  justify-content: center;
+  align-items: center;
+  width: 250px;
+  height: 100px;
+  background-color: ${({ theme }) => theme.color.white};
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+`;
+
+const SCloseBtn = styled.button`
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+  margin-top: 15px;
+`;

--- a/src/components/modal/ModalPortal.tsx
+++ b/src/components/modal/ModalPortal.tsx
@@ -1,0 +1,9 @@
+import { ReactElement } from 'react';
+import { createPortal } from 'react-dom';
+
+export default function Portal({ children }: { children: ReactElement }) {
+  const modalRoot =
+    typeof document === 'undefined' ? null : document.getElementById('_modal');
+
+  return modalRoot ? createPortal(children, modalRoot) : null;
+}

--- a/src/components/modal/ModalTest.tsx
+++ b/src/components/modal/ModalTest.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+import Portal from './ModalPortal';
+import Modal from './Modal';
+
+export default function ModalTest() {
+  const [isModalOpen, setModalOpen] = useState(false);
+  const openModal = () => setModalOpen(true);
+  const closeModal = () => setModalOpen(false);
+  return (
+    <SModalTestWrapper>
+      <button type="button" onClick={openModal}>
+        Open Modal
+      </button>
+      {isModalOpen && (
+        <Portal>
+          <Modal onClose={closeModal} />
+        </Portal>
+      )}
+    </SModalTestWrapper>
+  );
+}
+
+const SModalTestWrapper = styled.div`
+  text-align: center;
+  & button {
+    font-size: 1.125rem;
+    background-color: ${({ theme }) => theme.color.normal};
+    padding: 5px;
+    border-radius: 5px;
+    color: ${({ theme }) => theme.color.white};
+  }
+`;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -6,6 +6,7 @@ export default function Document() {
       <Head />
       <body>
         <Main />
+        <div id="_modal" />
         <NextScript />
       </body>
     </Html>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import Header from '@/components/common/Header';
 import Footer from '@/components/common/Footer';
+import ModalTest from '@/components/modal/ModalTest';
 
 export default function Home() {
   return (
@@ -13,6 +14,7 @@ export default function Home() {
       </Head>
       <main>
         <Header headerText="Title" rightText="인증패스" />
+        <ModalTest />
         <Footer />
       </main>
     </>


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호][branch] 이슈이름" 으로 작성해주세요 -->
close #9 

## ✨ 구현 기능 명세
- `createPortal`을 사용하여, Modal을 다른 DOM 노드로 렌더링하는 Portal 컴포넌트 생성
- Modal 컴포넌트 생성
- 배경 클릭 시 모달을 닫는 로직 추가

## 🎁 PR Point
- Modal은 컨텐츠가 렌더링되는 DOM이 아닌 다른 DOM에서 렌더링되고 있기 때문에 크기를  main에 맞춰 조정할 수가 없다는 점 참고 부탁드립니다.
- 모달 테스트만을 위한 코드로, UI 디자인은 고려하지 않았습니다. UI 디자인이 확정이 나면 적절한 반응형 크기(`min-width`, `max-width` 등)를 지정해주어야 합니다.

## 🕰 소요시간
1시간

## 😭 어려웠던 점
Next에서 Portal을 쓸 때 주의해야 할 점이, SSR 환경에서는 `document` 객체에 접근할 수 없다는 것입니다. 이로 인한 문제를 방지하기 위한 방법을 고민하는 시간이 오래 걸렸습니다. 우선 CSR일 때만 `document.getElementById()`를 호출하도록 `document`의 타입을 확인하는 코드를 추가하였습니다. 이를 통해 SSR일 때는 `null`을 반환하여 CSR일 때만 포탈이 생성이 되도록 하였습니다.
다만 실제 SSR 환경에선 예상치 못한 문제가 생길 수 있으므로 포탈 관련 에러가 발생할 경우 공유해주시면 함께 해결 방안을 찾아보겠습니다. 

<!-- (선택) -->
