### PR TITLE
[#19][FEATURE] 공통 컴포넌트 (헤더, 푸터) 동적 스타일링 및 props 정리

### DIFF
--- a/public/icons/index.ts
+++ b/public/icons/index.ts
@@ -1,0 +1,6 @@
+export * as homeNormal from './icon-home-normal.svg';
+export * as homeFilled from './icon-home-filled.svg';
+export * as myChallengeNormal from './icon-mychallenge-normal.svg';
+export * as myChallengeFilled from './icon-mychallenge-filled.svg';
+export * as profileNormal from './icon-profile-normal.svg';
+export * as profileFilled from './icon-profile-filled.svg';

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,40 +1,61 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import {
+  homeNormal,
+  homeFilled,
+  myChallengeNormal,
+  myChallengeFilled,
+  profileNormal,
+  profileFilled,
+} from '../../../public/icons';
 
 export default function Footer() {
+  const router = useRouter();
+
   return (
     <SFooterWrapper>
-      <SFooterIconBox href="/">
-        <Image
-          src="/icons/icon-home-filled.svg"
-          alt="홈 아이콘"
-          width={24}
-          height={24}
-          priority
-        />
-        <p>홈</p>
-      </SFooterIconBox>
-      <SFooterIconBox href="/mychallenge">
-        <Image
-          src="/icons/icon-mychallenge-normal.svg"
-          alt="마이 챌린지 아이콘"
-          width={24}
-          height={24}
-          priority
-        />
-        <p>마이 챌린지</p>
-      </SFooterIconBox>
-      <SFooterIconBox href="#">
-        <Image
-          src="/icons/icon-profile-normal.svg"
-          alt="프로필 아이콘"
-          width={24}
-          height={24}
-          priority
-        />
-        <p>프로필</p>
-      </SFooterIconBox>
+      <SFooterNavLink href="/">
+        <SFooterNavItem isActive={router.asPath === '/'}>
+          <Image
+            src={router.asPath === '/' ? homeFilled : homeNormal}
+            alt="홈 아이콘"
+            width={24}
+            height={24}
+            priority
+          />
+          <p>홈</p>
+        </SFooterNavItem>
+      </SFooterNavLink>
+      <SFooterNavLink href="/mychallenge">
+        <SFooterNavItem isActive={router.asPath === '/mychallenge'}>
+          <Image
+            src={
+              router.asPath === '/mychallenge'
+                ? myChallengeFilled
+                : myChallengeNormal
+            }
+            alt="마이 챌린지 아이콘"
+            width={24}
+            height={24}
+            priority
+          />
+          <p>마이 챌린지</p>
+        </SFooterNavItem>
+      </SFooterNavLink>
+      <SFooterNavLink href="/profile">
+        <SFooterNavItem isActive={router.asPath === '/profile'}>
+          <Image
+            src={router.asPath === '/profile' ? profileFilled : profileNormal}
+            alt="프로필 아이콘"
+            width={24}
+            height={24}
+            priority
+          />
+          <p>프로필</p>
+        </SFooterNavItem>
+      </SFooterNavLink>
     </SFooterWrapper>
   );
 }
@@ -43,22 +64,28 @@ const SFooterWrapper = styled.nav`
   z-index: 10;
   flex-shrink: 0;
   width: 100%;
-  height: 56px;
+  height: 91px;
   display: flex;
   flex-flow: row nowrap;
   justify-content: space-between;
-  gap: 56px;
+  gap: 3.5rem;
   font-size: 0.75rem;
   font-weight: ${({ theme }) => theme.fontWeight.bold};
   border-top: 1px solid #dee1e5;
-  padding: 10px 20px 0 20px;
+  padding: 0.625rem 1.25rem 2.375rem 1.25rem;
 `;
 
-const SFooterIconBox = styled(Link)`
+const SFooterNavLink = styled(Link)`
   width: 74px;
   height: 43px;
+`;
+
+const SFooterNavItem = styled.div<{ isActive: boolean }>`
   display: flex;
   flex-flow: column nowrap;
   align-items: center;
   justify-content: space-between;
+  color: ${({ isActive, theme }) => !isActive && theme.color.gray_83};
+  font-size: ${({ theme }) => theme.fontSize.caption1};
+  font-weight: ${({ theme }) => theme.fontWeight.caption1};
 `;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -5,9 +5,14 @@ import { useRouter } from 'next/router';
 interface IHeader {
   headerText?: string;
   rightText?: string;
+  rightOnClick?: () => void;
 }
 
-export default function Header({ headerText, rightText }: IHeader) {
+export default function Header({
+  headerText,
+  rightText,
+  rightOnClick,
+}: IHeader) {
   const router = useRouter();
   return (
     <SHeaderWrapper>
@@ -25,7 +30,7 @@ export default function Header({ headerText, rightText }: IHeader) {
         />
       </SBackBtn>
       <SHeaderCenter>{headerText && <span>{headerText}</span>}</SHeaderCenter>
-      <SHeaderRightChild>
+      <SHeaderRightChild onClick={rightOnClick}>
         <span>{rightText}</span>
       </SHeaderRightChild>
     </SHeaderWrapper>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -68,7 +68,7 @@ const SHeaderCenter = styled.div`
 const SHeaderRightChild = styled.div`
   position: absolute;
   right: 0;
-  margin-right: 18px;
+  margin-right: 1.125rem;
   font-size: 1rem;
   font-weight: ${({ theme }) => theme.fontWeight.medium};
 `;

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -12,6 +12,7 @@ interface ILayout {
   title?: string;
   description?: string;
   noFooter?: boolean;
+  rightOnClick?: () => void;
 }
 
 export default function Layout({
@@ -21,6 +22,7 @@ export default function Layout({
   title,
   description,
   noFooter,
+  rightOnClick,
 }: ILayout) {
   return (
     <SLayoutWrapper>
@@ -37,7 +39,11 @@ export default function Layout({
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <h1 className="a11yHidden">WAVED</h1>
-      <Header headerText={headerText} rightText={rightText} />
+      <Header
+        headerText={headerText}
+        rightText={rightText}
+        rightOnClick={rightOnClick}
+      />
       <main>{children}</main>
       {noFooter || <Footer />}
     </SLayoutWrapper>

--- a/src/components/common/Layout.tsx
+++ b/src/components/common/Layout.tsx
@@ -7,11 +7,12 @@ import Footer from '@/components/common/Footer';
 
 interface ILayout {
   children: React.ReactNode;
-  headerText: string;
+  headerText?: string;
   rightText?: string;
   title?: string;
   description?: string;
   noFooter?: boolean;
+  noHeader?: boolean;
   rightOnClick?: () => void;
 }
 
@@ -22,6 +23,7 @@ export default function Layout({
   title,
   description,
   noFooter,
+  noHeader,
   rightOnClick,
 }: ILayout) {
   return (
@@ -39,11 +41,13 @@ export default function Layout({
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <h1 className="a11yHidden">WAVED</h1>
-      <Header
-        headerText={headerText}
-        rightText={rightText}
-        rightOnClick={rightOnClick}
-      />
+      {noHeader || (
+        <Header
+          headerText={headerText}
+          rightText={rightText}
+          rightOnClick={rightOnClick}
+        />
+      )}
       <main>{children}</main>
       {noFooter || <Footer />}
     </SLayoutWrapper>

--- a/src/pages/example/index.tsx
+++ b/src/pages/example/index.tsx
@@ -14,12 +14,21 @@ export default function Example() {
 
     // router는 promise를 반환하는데 onClick 이벤트핸들러는 반환값을 처리하지 않기 때문에 이벤트 핸들러 내에서 직접적으로 promise를 처리하지 않고 따로 처리할 수 있도록 catch를 추가하여 사용해야 합니다.
   };
+
+  const handleEditProfile = () => {
+    router.push('/').catch((error) => {
+      console.error('페이지 이동에 실패하였습니다.', error);
+    });
+    console.log('프로필 수정 후 프로필 페이지 이동하였습니다.');
+  };
+
   return (
     <Layout
       title="공통 컴포넌트 예시"
       description="각 최상위 페이지에 지금과 같이 HeadMeta를 사용하면 됩니다. 공통 컴포넌트 예시를 모아두기 위한 페이지입니다. 배포 이전 삭제 예정입니다."
       headerText="마이 챌린지"
-      rightText="인증패스"
+      rightText="수정하기"
+      rightOnClick={handleEditProfile}
       noFooter
     >
       <TabMenu

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,0 +1,5 @@
+import Layout from '@/components/common/Layout';
+
+export default function Profile() {
+  return <Layout noHeader>index</Layout>;
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호][branch] 이슈이름" 으로 작성해주세요 -->

close #19 

## ✨ 구현 기능 명세
- Header컴포넌트의 props 정리 (모든 페이지에서 활용가능하도록)
- Header가 없을 경우의 레이아웃 props 추가
- 현재 페이지에 따라 Footer(Nav)의 요소가 활성화/비활성화되는 동적 스타일링 적용

## 🎁 PR Point
```tsx
  noHeader?: boolean;
  rightOnClick?: () => void;
```
Header 컴포넌트에서 전달 받는 props에 `rightOnClick`과 `noHeader`를 추가하였습니다.
 `rightOnClick`은 헤더의 `rightChild` 위치에 `onClick` 이벤트가 추가될 경우 수행되는 함수입니다. 또한 Header가 필요없는 경우에 `noHeader(true)`를 전달하면 Header가 없는 레이아웃을 사용할 수 있습니다.

`example` 컴포넌트에 예시 코드를 추가했으니 참고하시길 바랍니다.


## 🕰 소요시간
약 1시간


<!-- (선택) -->
