### PR TITLE
[#50][FEATURE] 마이챌린지 진행완료 섹션 디자인 수정사항 반영 

### DIFF
--- a/src/atoms/modal.ts
+++ b/src/atoms/modal.ts
@@ -1,0 +1,17 @@
+import { atom } from 'recoil';
+import { IModalState } from '@/types/modal';
+
+const modalState = atom<IModalState>({
+  key: 'modalState',
+  default: {
+    isOpen: false,
+    mainText: '',
+    subText: '',
+    image: '',
+    btnText: '',
+    cancelBtnText: '',
+    onClick: () => {},
+  },
+});
+
+export default modalState;

--- a/src/components/common/Btn.tsx
+++ b/src/components/common/Btn.tsx
@@ -6,7 +6,7 @@ interface IBtn {
   text: string;
   styleType: 'primary' | 'gray' | 'white' | 'white_line' | 'disabled';
   size: 'large' | 'small';
-  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+  onClick?: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 }
 
 interface IBtnWrapper {

--- a/src/components/common/WriteLayout.tsx
+++ b/src/components/common/WriteLayout.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useCallback, useEffect, useState } from 'react';
 import Btn from './Btn';
 import writeLayoutText from '@/constants/writeLayoutText';
+import useModal from '@/hooks/useModal';
 
 export type TPageType =
   | '후기작성'
@@ -17,7 +18,7 @@ interface IWriteLayout {
   isLinkValid?: boolean | undefined;
   children: React.ReactNode;
   handleSubmit?: (e: React.FormEvent<HTMLFormElement>) => void;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
 export default function WriteLayout({
@@ -33,6 +34,7 @@ export default function WriteLayout({
   const { btnText } = writeLayoutText[pageType];
   const [isBtnActive, setIsBtnActive] = useState(false);
   const isVerificationPage = pageType.includes('인증');
+  const { openModal } = useModal();
 
   const checkValidation = useCallback(() => {
     switch (pageType) {
@@ -67,7 +69,18 @@ export default function WriteLayout({
               text: btnText,
               styleType: isBtnActive ? 'primary' : 'disabled',
               size: 'large',
-              onClick: isVerificationPage ? onClick : undefined,
+              onClick:
+                isVerificationPage && onClick !== undefined
+                  ? () =>
+                      openModal({
+                        image: '/icons/icon-exclamation-mark.svg',
+                        mainText: '인증을 제출 하시겠습니까?',
+                        subText:
+                          '인증하기 제출 후 수정, 삭제할 수 없으니 확인 후 올려주시기 바랍니다.',
+                        btnText: '제출하기',
+                        onClick,
+                      })
+                  : undefined,
             },
           ]}
         />

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import Image from 'next/image';
 import Btn from '../common/Btn';
 import useModal from '@/hooks/useModal';
+import Portal from './ModalPortal';
 
 export default function Modal() {
   const { modalData, closeModal } = useModal();
@@ -14,41 +15,43 @@ export default function Modal() {
 
   return (
     modalData.isOpen && (
-      <SModalWrapper onClick={handleBackgroundClick}>
-        <SModalContent>
-          {modalData.image && (
-            <SModalImage
-              src={modalData.image}
-              alt="모달 이미지"
-              width={88}
-              height={88}
-              priority
+      <Portal>
+        <SModalWrapper onClick={handleBackgroundClick}>
+          <SModalContent>
+            {modalData.image && (
+              <SModalImage
+                src={modalData.image}
+                alt="모달 이미지"
+                width={88}
+                height={88}
+                priority
+              />
+            )}
+            <SModalMainText marginBottom={!!modalData.subText}>
+              {modalData.mainText}
+            </SModalMainText>
+            {modalData.subText && (
+              <SModalSubText>{modalData.subText}</SModalSubText>
+            )}
+            <Btn
+              btns={[
+                {
+                  text: modalData.cancelBtnText || '아니요',
+                  styleType: 'gray',
+                  size: 'small',
+                  onClick: closeModal,
+                },
+                {
+                  text: modalData.btnText,
+                  styleType: 'primary',
+                  size: 'small',
+                  onClick: modalData.onClick,
+                },
+              ]}
             />
-          )}
-          <SModalMainText marginBottom={!!modalData.subText}>
-            {modalData.mainText}
-          </SModalMainText>
-          {modalData.subText && (
-            <SModalSubText>{modalData.subText}</SModalSubText>
-          )}
-          <Btn
-            btns={[
-              {
-                text: modalData.cancelBtnText || '아니요',
-                styleType: 'gray',
-                size: 'small',
-                onClick: closeModal,
-              },
-              {
-                text: modalData.btnText,
-                styleType: 'primary',
-                size: 'small',
-                onClick: modalData.onClick,
-              },
-            ]}
-          />
-        </SModalContent>
-      </SModalWrapper>
+          </SModalContent>
+        </SModalWrapper>
+      </Portal>
     )
   );
 }

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,62 +1,55 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import Btn from '../common/Btn';
+import useModal from '@/hooks/useModal';
 
-interface IModal {
-  mainText: string;
-  subText?: string;
-  image?: string;
-  btnText: string;
-  onClick: (e: React.MouseEvent<HTMLElement>) => void;
-  onClose: () => void;
-}
+export default function Modal() {
+  const { modalData, closeModal } = useModal();
 
-export default function Modal({
-  mainText,
-  subText,
-  image,
-  btnText,
-  onClick,
-  onClose,
-}: IModal) {
   const handleBackgroundClick = (event: React.MouseEvent<HTMLElement>) => {
     if (event.target === event.currentTarget) {
-      onClose();
+      closeModal();
     }
   };
 
   return (
-    <SModalWrapper onClick={handleBackgroundClick}>
-      <SModalContent>
-        {image && (
-          <SModalImage
-            src={image}
-            alt="모달 이미지"
-            width={88}
-            height={88}
-            priority
+    modalData.isOpen && (
+      <SModalWrapper onClick={handleBackgroundClick}>
+        <SModalContent>
+          {modalData.image && (
+            <SModalImage
+              src={modalData.image}
+              alt="모달 이미지"
+              width={88}
+              height={88}
+              priority
+            />
+          )}
+          <SModalMainText marginBottom={!!modalData.subText}>
+            {modalData.mainText}
+          </SModalMainText>
+          {modalData.subText && (
+            <SModalSubText>{modalData.subText}</SModalSubText>
+          )}
+          <Btn
+            btns={[
+              {
+                text: modalData.cancelBtnText || '아니요',
+                styleType: 'gray',
+                size: 'small',
+                onClick: closeModal,
+              },
+              {
+                text: modalData.btnText,
+                styleType: 'primary',
+                size: 'small',
+                onClick: modalData.onClick,
+              },
+            ]}
           />
-        )}
-        <SModalMainText marginBottom={!!subText}>{mainText}</SModalMainText>
-        {subText && <SModalSubText>{subText}</SModalSubText>}
-        <Btn
-          btns={[
-            {
-              text: '아니요',
-              styleType: 'gray',
-              size: 'small',
-              onClick: onClose,
-            },
-            {
-              text: btnText,
-              styleType: 'primary',
-              size: 'small',
-              onClick,
-            },
-          ]}
-        />
-      </SModalContent>
-    </SModalWrapper>
+        </SModalContent>
+      </SModalWrapper>
+    )
   );
 }
 
@@ -80,7 +73,7 @@ const SModalContent = styled.div`
   align-items: center;
   width: 19.5rem;
   background-color: ${({ theme }) => theme.color.white};
-  padding: 2rem 1rem 0.75rem 1rem;
+  padding: 2rem 1rem 1rem 1rem;
   border-radius: 8px;
 `;
 

--- a/src/components/modal/ModalTest.tsx
+++ b/src/components/modal/ModalTest.tsx
@@ -1,32 +1,32 @@
 import { useState } from 'react';
 import styled from '@emotion/styled';
-import Portal from './ModalPortal';
 import Modal from './Modal';
+import useModal from '@/hooks/useModal';
 
 export default function ModalTest() {
-  const [isModalOpen, setModalOpen] = useState(false);
-  const openModal = () => setModalOpen(true);
-  const closeModal = () => setModalOpen(false);
+  const { openModal, closeModal } = useModal();
   const clickModalBtn = () => {
     console.log('모달 내 버튼 클릭시 필요한 동작 함수');
   };
   return (
     <SModalTestWrapper>
-      <button type="button" onClick={openModal}>
-        Open Modal
-      </button>
-      {isModalOpen && (
-        <Portal>
-          <Modal
-            image="/icons/icon-exclamation-mark.svg"
-            mainText="메인텍스트"
-            subText="이 자리에 서브텍스트 입력하시면 됩니다. 서브텍스트가 없다면 아예 생략하시면 됩니다."
-            btnText="출력하기"
-            onClick={clickModalBtn}
-            onClose={closeModal}
-          />
-        </Portal>
-      )}
+      <button
+        type="button"
+        onClick={() => {
+          () =>
+            openModal({
+              image: '/icons/icon-exclamation-mark.svg',
+              mainText: '모달 테스트를 하시겠습니까?',
+              subText: '모달동작을 테스트하고자 하면 예를 눌러주세요.',
+              btnText: '예',
+              onClick: () => {
+                clickModalBtn();
+                closeModal();
+              },
+            });
+        }}
+      ></button>
+      <Modal />
     </SModalTestWrapper>
   );
 }

--- a/src/components/mychallenge/ChallengeBtn.tsx
+++ b/src/components/mychallenge/ChallengeBtn.tsx
@@ -20,9 +20,9 @@ export default function ChallengeBtn({
   status,
 }: TBtn) {
   const isAble = (() => {
-    return status === 'progress'
+    return status === 'PROGRESS'
       ? !isVerified
-      : status === 'completed' && !isReviewed;
+      : status === 'COMPLETED' && !isReviewed;
   })();
 
   const preventLink = (e: React.MouseEvent<HTMLElement>) => {
@@ -32,7 +32,7 @@ export default function ChallengeBtn({
   };
 
   switch (status) {
-    case 'progress':
+    case 'PROGRESS':
       return (
         <SBtnWrapper>
           <SLink
@@ -68,7 +68,7 @@ export default function ChallengeBtn({
           )}
         </SBtnWrapper>
       );
-    case 'waiting':
+    case 'WAITING':
       return (
         <SBtnWrapper>
           <SBtn styleType="gray">
@@ -76,7 +76,7 @@ export default function ChallengeBtn({
           </SBtn>
         </SBtnWrapper>
       );
-    case 'completed':
+    case 'COMPLETED':
       return (
         <SBtnWrapper>
           <SLink href="#">

--- a/src/components/mychallenge/ChallengeBtn.tsx
+++ b/src/components/mychallenge/ChallengeBtn.tsx
@@ -1,7 +1,9 @@
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 import { TMyChallengeInfo, TMyChallengeStatus } from '@/types/myChallenge';
 import calculateDDay from '@/utils/calculateDDay';
+import useModal from '@/hooks/useModal';
 
 interface IBtn
   extends Omit<
@@ -21,6 +23,8 @@ export default function ChallengeBtn({
   startDate,
   status,
 }: IBtn) {
+  const router = useRouter();
+  const { openModal } = useModal();
   const isAble = (() => {
     return status === 'PROGRESS'
       ? !isVerified
@@ -31,6 +35,28 @@ export default function ChallengeBtn({
     if (!isAble) {
       e.preventDefault(); // 버튼이 비활성화 상태일 때 링크 이동 중지
     }
+  };
+
+  const getRefund = () => {
+    openModal({
+      image: '/icons/icon-done.svg',
+      mainText: '환급 신청이 완료되었습니다.',
+      subText: '참여한 챌린지가 어떠했는지 여러분의 소중한 후기를 남겨주세요.',
+      btnText: '후기 작성',
+      cancelBtnText: '나중에 하기',
+      onClick: () => {
+        router
+          .push({
+            pathname: `/mychallenge/review`,
+            query: {
+              challengeId: groupId,
+            },
+          })
+          .catch((error) => {
+            console.error('페이지 이동에 실패하였습니다.', error);
+          });
+      },
+    });
   };
 
   switch (status) {
@@ -49,7 +75,18 @@ export default function ChallengeBtn({
             <SBtn
               as="button"
               styleType="middle"
-              onClick={() => console.log('제출확인 모달 오픈')}
+              onClick={() =>
+                openModal({
+                  image: '/icons/icon-exclamation-mark.svg',
+                  mainText: '인증을 제출 하시겠습니까?',
+                  subText:
+                    '인증하기 제출 후 수정, 삭제할 수 없으니 확인 후 올려주시기 바랍니다.',
+                  btnText: '제출하기',
+                  onClick: () => {
+                    console.log('인증제출하기');
+                  },
+                })
+              }
             >
               인증 하기
             </SBtn>
@@ -85,18 +122,14 @@ export default function ChallengeBtn({
             <SBtn styleType="light">인증 내역</SBtn>
           </SLink>
           {isSuccessed && !isRefunded ? (
-            <SBtn
-              as="button"
-              styleType="middle"
-              onClick={() => console.log('환급신청완료 모달 오픈')}
-            >
+            <SBtn as="button" styleType="middle" onClick={getRefund}>
               환급 신청
             </SBtn>
           ) : (
             <SLink
               href={{
                 pathname: `/mychallenge/review`,
-                query: { groupId },
+                query: { challengeId: groupId },
               }}
               as="mychallenge/review"
             >

--- a/src/components/mychallenge/ChallengeBtn.tsx
+++ b/src/components/mychallenge/ChallengeBtn.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { TMyChallengeInfo, TMyChallengeStatus } from '@/types/myChallenge';
 import calculateDDay from '@/utils/calculateDDay';
 
-interface TBtn
+interface IBtn
   extends Omit<
     TMyChallengeInfo,
     'myChallengeId' | 'groupTitle' | 'endDate' | 'successCount' | 'deposit'
@@ -20,7 +20,7 @@ export default function ChallengeBtn({
   verificationType,
   startDate,
   status,
-}: TBtn) {
+}: IBtn) {
   const isAble = (() => {
     return status === 'PROGRESS'
       ? !isVerified
@@ -49,7 +49,7 @@ export default function ChallengeBtn({
             <SBtn
               as="button"
               styleType="middle"
-              onClick={() => console.log('test')}
+              onClick={() => console.log('제출확인 모달 오픈')}
             >
               인증 하기
             </SBtn>
@@ -84,24 +84,30 @@ export default function ChallengeBtn({
           <SLink href="#">
             <SBtn styleType="light">인증 내역</SBtn>
           </SLink>
-          <SLink
-            href={{
-              pathname: `/mychallenge/review`,
-              query: { groupId },
-            }}
-            as="mychallenge/review"
-          >
-            {isSuccessed && !isRefunded ? (
-              <SBtn styleType="middle">환급 신청</SBtn>
-            ) : (
+          {isSuccessed && !isRefunded ? (
+            <SBtn
+              as="button"
+              styleType="middle"
+              onClick={() => console.log('환급신청완료 모달 오픈')}
+            >
+              환급 신청
+            </SBtn>
+          ) : (
+            <SLink
+              href={{
+                pathname: `/mychallenge/review`,
+                query: { groupId },
+              }}
+              as="mychallenge/review"
+            >
               <SBtn
                 styleType={isAble ? 'border' : 'bordergray'}
                 onClick={preventLink}
               >
                 {isAble ? '후기 작성' : '작성 완료'}
               </SBtn>
-            )}
-          </SLink>
+            </SLink>
+          )}
         </SBtnWrapper>
       );
     default:

--- a/src/components/mychallenge/ChallengeBtn.tsx
+++ b/src/components/mychallenge/ChallengeBtn.tsx
@@ -24,7 +24,7 @@ export default function ChallengeBtn({
   status,
 }: IBtn) {
   const router = useRouter();
-  const { openModal } = useModal();
+  const { openModal, closeModal } = useModal();
   const isAble = (() => {
     return status === 'PROGRESS'
       ? !isVerified
@@ -55,6 +55,7 @@ export default function ChallengeBtn({
           .catch((error) => {
             console.error('페이지 이동에 실패하였습니다.', error);
           });
+        closeModal();
       },
     });
   };
@@ -84,6 +85,7 @@ export default function ChallengeBtn({
                   btnText: '제출하기',
                   onClick: () => {
                     console.log('인증제출하기');
+                    closeModal();
                   },
                 })
               }

--- a/src/components/mychallenge/ChallengeBtn.tsx
+++ b/src/components/mychallenge/ChallengeBtn.tsx
@@ -4,9 +4,9 @@ import { TMyChallengeInfo, TMyChallengeStatus } from '@/types/myChallenge';
 import calculateDDay from '@/utils/calculateDDay';
 
 interface TBtn
-  extends Pick<
+  extends Omit<
     TMyChallengeInfo,
-    'groupId' | 'isReviewed' | 'isVerified' | 'verificationType' | 'startDate'
+    'myChallengeId' | 'groupTitle' | 'endDate' | 'successCount' | 'deposit'
   > {
   status: TMyChallengeStatus;
 }
@@ -15,6 +15,8 @@ export default function ChallengeBtn({
   groupId,
   isReviewed,
   isVerified,
+  isSuccessed,
+  isRefunded,
   verificationType,
   startDate,
   status,
@@ -89,12 +91,16 @@ export default function ChallengeBtn({
             }}
             as="mychallenge/review"
           >
-            <SBtn
-              styleType={isAble ? 'border' : 'bordergray'}
-              onClick={preventLink}
-            >
-              {isAble ? '후기 작성' : '작성 완료'}
-            </SBtn>
+            {isSuccessed && !isRefunded ? (
+              <SBtn styleType="middle">환급 신청</SBtn>
+            ) : (
+              <SBtn
+                styleType={isAble ? 'border' : 'bordergray'}
+                onClick={preventLink}
+              >
+                {isAble ? '후기 작성' : '작성 완료'}
+              </SBtn>
+            )}
           </SLink>
         </SBtnWrapper>
       );

--- a/src/components/mychallenge/ChallengeItem.tsx
+++ b/src/components/mychallenge/ChallengeItem.tsx
@@ -57,6 +57,8 @@ export default function ChallengeItem({
         groupId={groupId}
         isReviewed={isReviewed}
         isVerified={isVerified}
+        isSuccessed={isSuccessed}
+        isRefunded={isRefunded}
         verificationType={verificationType}
         startDate={startDate}
         status={status}

--- a/src/components/mychallenge/ChallengeItem.tsx
+++ b/src/components/mychallenge/ChallengeItem.tsx
@@ -5,6 +5,7 @@ import ChallengeProgress from '@/components/mychallenge/ChallengeProgress';
 import ChallengeBtn from '@/components/mychallenge/ChallengeBtn';
 import parseDate from '@/utils/parseDate';
 import changePriceFormat from '@/utils/changePriceFormat';
+import ChallengeLabel from './ChallengeLabel';
 
 interface TMyChallengeItem extends Omit<TMyChallengeInfo, 'myChallengeId'> {
   status: TMyChallengeStatus;
@@ -19,27 +20,33 @@ export default function ChallengeItem({
   successCount,
   isReviewed,
   isVerified,
+  isSuccessed,
+  isRefunded,
   verificationType,
   deposit,
 }: TMyChallengeItem) {
-  const startdate = parseDate(startDate);
-  const enddate = parseDate(endDate);
+  const [startYY, startMM, startDD] = parseDate(startDate);
+  const [endYY, endMM, endDD] = parseDate(endDate);
 
   return (
     <SWrapper>
+      {status === 'COMPLETED' && (
+        <ChallengeLabel isSuccessed={isSuccessed} isRefunded={isRefunded} />
+      )}
       <SInfoWrapper>
         <h3>{groupTitle}</h3>
         <div>
           <SDuration>
-            {startdate[1]}/{startdate[2]}~{enddate[1]}/{enddate[2]}, 매일
+            {startYY}.{startMM}.{startDD}~{endYY}.{endMM}.{endDD}
           </SDuration>
           <SDeposit>
             <span>예치금</span>
             <span>{changePriceFormat(deposit)}원</span>
           </SDeposit>
         </div>
+        <SDetailBtn href={`/challenge/${groupId}`} />
       </SInfoWrapper>
-      {status === 'progress' && (
+      {status === 'PROGRESS' && (
         <ChallengeProgress
           successCount={successCount}
           startDate={startDate}
@@ -54,16 +61,11 @@ export default function ChallengeItem({
         startDate={startDate}
         status={status}
       />
-      <SDetailBtn href={`/challenge/${groupId}`} />
     </SWrapper>
   );
 }
 
 const SWrapper = styled.li`
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  position: relative;
   padding: 1rem;
   background-color: ${({ theme }) => theme.color.white};
   box-shadow: 0px 2px 15px 0 rgba(35, 62, 112, 0.15);
@@ -73,8 +75,8 @@ const SWrapper = styled.li`
 const SDetailBtn = styled(Link)`
   display: block;
   position: absolute;
-  top: 1rem;
-  right: 1rem;
+  top: 0;
+  right: 0;
   width: 24px;
   height: 24px;
   background: url('/icons/icon-left-arrow.svg') no-repeat center;
@@ -82,6 +84,9 @@ const SDetailBtn = styled(Link)`
 `;
 
 const SInfoWrapper = styled.div`
+  position: relative;
+  margin-bottom: 1rem;
+
   h3 {
     font-size: ${({ theme }) => theme.fontSize.body2};
     line-height: 1.5rem;

--- a/src/components/mychallenge/ChallengeLabel.tsx
+++ b/src/components/mychallenge/ChallengeLabel.tsx
@@ -1,0 +1,39 @@
+import { TMyChallengeInfo } from '@/types/myChallenge';
+import styled from '@emotion/styled';
+
+export default function ChallengeLabel({
+  isSuccessed,
+  isRefunded,
+}: Pick<TMyChallengeInfo, 'isSuccessed' | 'isRefunded'>) {
+  const labelStatus = (() => {
+    if (isSuccessed) {
+      return isRefunded ? '환급 완료' : '달성 완료';
+    }
+    return '달성 실패';
+  })();
+  return <SLabel labelStatus={labelStatus}>{labelStatus}</SLabel>;
+}
+
+const SLabel = styled.span<{
+  labelStatus: '달성 완료' | '달성 실패' | '환급 완료';
+}>`
+  display: block;
+  width: fit-content;
+  padding: 0.25rem 0.5rem;
+  font-size: ${({ theme }) => theme.fontSize.caption2};
+  font-weight: ${({ theme }) => theme.fontWeight.caption2};
+  color: ${({ labelStatus, theme }) =>
+    ({
+      '달성 완료': theme.color.positive,
+      '달성 실패': theme.color.error,
+      '환급 완료': theme.color.gray_83,
+    })[labelStatus]};
+  background-color: ${({ labelStatus, theme }) =>
+    ({
+      '달성 완료': '#E9F7EB',
+      '달성 실패': '#FCE7E8',
+      '환급 완료': theme.color.gray_ec,
+    })[labelStatus]};
+  margin-bottom: 0.625rem;
+  border-radius: 16px;
+`;

--- a/src/components/mychallenge/ChallengeLabel.tsx
+++ b/src/components/mychallenge/ChallengeLabel.tsx
@@ -1,5 +1,5 @@
-import { TMyChallengeInfo } from '@/types/myChallenge';
 import styled from '@emotion/styled';
+import { TMyChallengeInfo } from '@/types/myChallenge';
 
 export default function ChallengeLabel({
   isSuccessed,

--- a/src/components/mychallenge/ChallengeProgress.tsx
+++ b/src/components/mychallenge/ChallengeProgress.tsx
@@ -43,7 +43,9 @@ export default function ChallengeProgress({
   );
 }
 
-const SWrapper = styled.div``;
+const SWrapper = styled.div`
+  margin-bottom: 1rem;
+`;
 
 const SProgressWrapper = styled.div`
   padding-bottom: 1rem;

--- a/src/components/profile/myreview/MyReviewItem.tsx
+++ b/src/components/profile/myreview/MyReviewItem.tsx
@@ -1,9 +1,8 @@
-import { useState } from 'react';
 import styled from '@emotion/styled';
 import Link from 'next/link';
 import IMyReview from '@/types/myReview';
-import Portal from '@/components/modal/ModalPortal';
 import Modal from '@/components/modal/Modal';
+import useModal from '@/hooks/useModal';
 
 interface IMyReviewItem extends IMyReview {
   onDelete: () => void;
@@ -16,9 +15,7 @@ export default function MyReviewItem({
   context,
   onDelete,
 }: IMyReviewItem) {
-  const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
-  const openDeleteModal = () => setDeleteModalOpen(true);
-  const closeDeleteModal = () => setDeleteModalOpen(false);
+  const { openModal, closeModal } = useModal();
   return (
     <>
       <SMyReviewItem>
@@ -37,24 +34,23 @@ export default function MyReviewItem({
           >
             수정
           </SEditBtn>
-          <SDeleteBtn type="button" onClick={openDeleteModal}>
+          <SDeleteBtn
+            type="button"
+            onClick={() =>
+              openModal({
+                mainText: '남기신 후기를 삭제하시겠습니까?',
+                btnText: '삭제하기',
+                onClick: () => {
+                  onDelete();
+                  closeModal();
+                },
+              })
+            }
+          >
             삭제
           </SDeleteBtn>
         </SBtnWrapper>
       </SMyReviewItem>
-      {isDeleteModalOpen && (
-        <Portal>
-          <Modal
-            mainText="남기신 후기를 삭제하시겠습니까?"
-            btnText="삭제하기"
-            onClick={() => {
-              onDelete();
-              closeDeleteModal();
-            }}
-            onClose={closeDeleteModal}
-          />
-        </Portal>
-      )}
     </>
   );
 }

--- a/src/components/verification/collection/Stamp.tsx
+++ b/src/components/verification/collection/Stamp.tsx
@@ -9,7 +9,7 @@ interface IStamp {
 }
 
 export default function Stamp({ results, startDate }: IStamp) {
-  const diff = calculateDDay(startDate);
+  const diff = Math.abs(calculateDDay(startDate));
   const resultStamps = results.map((value, index) => {
     if (index <= diff - 1 && value === 0) {
       return 1;

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react';
+import { useRecoilState } from 'recoil';
+import { IModal } from '@/types/modal';
+import modalState from '@/atoms/modal';
+
+export default function useModal() {
+  const [modalData, setModalData] = useRecoilState(modalState);
+
+  const openModal = useCallback(
+    ({
+      mainText,
+      subText = '',
+      image = '',
+      btnText,
+      cancelBtnText = '',
+      onClick,
+    }: IModal) => {
+      setModalData({
+        isOpen: true,
+        mainText,
+        subText,
+        image,
+        btnText,
+        cancelBtnText,
+        onClick,
+      });
+    },
+    [setModalData],
+  );
+
+  const closeModal = useCallback(() => {
+    setModalData({
+      isOpen: false,
+      mainText: '',
+      subText: '',
+      image: '',
+      btnText: '',
+      onClick: () => {},
+    });
+  }, [setModalData]);
+
+  return { modalData, openModal, closeModal };
+}

--- a/src/pages/mychallenge/index.tsx
+++ b/src/pages/mychallenge/index.tsx
@@ -10,6 +10,8 @@ import ChallengeSection from '@/components/mychallenge/ChallengeSection';
 import ChallengeEmptyView from '@/components/mychallenge/ChallengeEmptyView';
 import SnackBar from '@/components/common/SnackBar';
 import { TMyChallengeInfo } from '@/types/myChallenge';
+import Portal from '@/components/modal/ModalPortal';
+import Modal from '@/components/modal/Modal';
 
 const progressData: TMyChallengeInfo[] = [
   {
@@ -202,6 +204,9 @@ export default function MyChallenge() {
       {snackBarState.open && (
         <SnackBar text={snackBarState.text} type={snackBarState.type} />
       )}
+      <Portal>
+        <Modal />
+      </Portal>
     </Layout>
   );
 }

--- a/src/pages/mychallenge/index.tsx
+++ b/src/pages/mychallenge/index.tsx
@@ -83,10 +83,12 @@ const completedData: TMyChallengeInfo[] = [
     groupId: 1,
     groupTitle: '백엔드 기술면접 챌린지 1기',
     startDate: '2024-03-01T00:00:00+09:00',
-    endDate: '2024-04-14T00:00:00+09:00',
+    endDate: '2024-03-14T00:00:00+09:00',
     successCount: 14,
-    isReviewed: true,
+    isReviewed: false,
     isVerified: null,
+    isSuccessed: true,
+    isRefunded: false,
     verificationType: 'TEXT',
     deposit: 20000,
   },
@@ -99,6 +101,22 @@ const completedData: TMyChallengeInfo[] = [
     successCount: 13,
     isReviewed: false,
     isVerified: null,
+    isSuccessed: false,
+    isRefunded: false,
+    verificationType: 'PICTURE',
+    deposit: 10000,
+  },
+  {
+    myChallengeId: 15,
+    groupId: 15,
+    groupTitle: '테스트 챌린지 1기',
+    startDate: '2024-01-01T00:00:00+09:00',
+    endDate: '2024-01-14T00:00:00+09:00',
+    successCount: 13,
+    isReviewed: true,
+    isVerified: null,
+    isSuccessed: true,
+    isRefunded: true,
     verificationType: 'PICTURE',
     deposit: 10000,
   },
@@ -147,9 +165,9 @@ export default function MyChallenge() {
     >
       <TabMenu
         tabs={[
-          { href: '#progress', text: '진행 중' },
-          { href: '#waiting', text: '대기 중' },
-          { href: '#completed', text: '진행 완료' },
+          { href: '#PROGRESS', text: '진행 중' },
+          { href: '#WAITING', text: '대기 중' },
+          { href: '#COMPLETED', text: '진행 완료' },
         ]}
       />
 
@@ -157,21 +175,21 @@ export default function MyChallenge() {
         {progressData.length !== 0 && (
           <ChallengeSection
             mainText="🧑🏻‍💻 진행 중"
-            status="progress"
+            status="PROGRESS"
             challenges={progressData}
           />
         )}
         {waitingData.length !== 0 && (
           <ChallengeSection
             mainText="📚 대기 중"
-            status="waiting"
+            status="WAITING"
             challenges={waitingData}
           />
         )}
         {completedData.length !== 0 && (
           <ChallengeSection
             mainText="🥳 진행 완료"
-            status="completed"
+            status="COMPLETED"
             challenges={completedData}
           />
         )}

--- a/src/pages/mychallenge/index.tsx
+++ b/src/pages/mychallenge/index.tsx
@@ -4,13 +4,12 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import REVIEW_SNACKBAR_TEXT from '@/constants/reviewSnackBarText';
 import ISnackBarState from '@/types/snackbar';
+import { TMyChallengeInfo } from '@/types/myChallenge';
 import Layout from '@/components/common/Layout';
 import TabMenu from '@/components/common/TabMenu';
 import ChallengeSection from '@/components/mychallenge/ChallengeSection';
 import ChallengeEmptyView from '@/components/mychallenge/ChallengeEmptyView';
 import SnackBar from '@/components/common/SnackBar';
-import { TMyChallengeInfo } from '@/types/myChallenge';
-import Portal from '@/components/modal/ModalPortal';
 import Modal from '@/components/modal/Modal';
 
 const progressData: TMyChallengeInfo[] = [
@@ -204,9 +203,7 @@ export default function MyChallenge() {
       {snackBarState.open && (
         <SnackBar text={snackBarState.text} type={snackBarState.type} />
       )}
-      <Portal>
-        <Modal />
-      </Portal>
+      <Modal />
     </Layout>
   );
 }

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -10,18 +10,16 @@ import JOBTITLE from '@/constants/jobTitle';
 import ProfileShortcut from '@/components/profile/ProfileShortcut';
 import SnackBar from '@/components/common/SnackBar';
 import profileSnackBarText from '@/constants/profileSnackBarText';
-import Portal from '@/components/modal/ModalPortal';
 import Modal from '@/components/modal/Modal';
 import ISnackBarState from '@/types/snackbar';
 import { logoutApi } from '@/lib/axios/profile/api';
+import useModal from '@/hooks/useModal';
 
 export default function Profile() {
   const router = useRouter();
   const { query } = useRouter();
-  const [isModalOpen, setModalOpen] = useState(false);
+  const { openModal, closeModal } = useModal();
   const [modalState, setModalState] = useState<string>('');
-  const openModal = () => setModalOpen(true);
-  const closeModal = () => setModalOpen(false);
 
   const cookieToken = getCookie('accessToken');
   const isLogined = !!cookieToken;
@@ -211,8 +209,17 @@ export default function Profile() {
               <button
                 type="button"
                 onClick={() => {
-                  openModal();
-                  setModalState('logout');
+                  openModal({
+                    image: '/icons/icon-exclamation-mark.svg',
+                    mainText: '로그아웃',
+                    subText: '로그아웃하시겠습니까?',
+                    btnText: '로그아웃',
+                    onClick: () => {
+                      handleLogout();
+                      setModalState('logout');
+                      closeModal();
+                    },
+                  });
                 }}
               >
                 로그아웃
@@ -290,8 +297,18 @@ export default function Profile() {
             <button
               type="button"
               onClick={() => {
-                openModal();
-                setModalState('withdrawal');
+                openModal({
+                  image: '/icons/icon-exclamation-mark.svg',
+                  mainText: '정말 계정을 탈퇴하시겠습니까?',
+                  subText:
+                    '탈퇴 이후에 예치금을 돌려받으실 수 없으며, 등록된 정보는 전부 삭제되어 재가입 후에도 확인하실 수 없습니다.',
+                  btnText: '네, 탈퇴할게요.',
+                  onClick: () => {
+                    handleLogout(); // 탈퇴로직이 없는것같아서 일단 로그아웃함수로...
+                    setModalState('withdrawal');
+                    closeModal();
+                  },
+                });
               }}
             >
               회원 탈퇴
@@ -302,26 +319,7 @@ export default function Profile() {
       {snackBarState.open && (
         <SnackBar text={snackBarState.text} type={snackBarState.type} />
       )}
-      {isModalOpen && (
-        <Portal>
-          <Modal
-            image="/icons/icon-exclamation-mark.svg"
-            mainText={
-              modalState === 'logout'
-                ? '로그아웃'
-                : '정말 계정을 탈퇴하시겠습니까?'
-            }
-            subText={
-              modalState === 'logout'
-                ? '로그아웃하시겠습니까?'
-                : '탈퇴 이후에 예치금을 돌려받으실 수 없으며, 등록된 정보는 전부 삭제되어 재가입 후에도 확인하실 수 없습니다.'
-            }
-            btnText={modalState === 'logout' ? '로그아웃' : '네, 탈퇴할게요.'}
-            onClick={clickModalBtn}
-            onClose={closeModal}
-          />
-        </Portal>
-      )}
+      <Modal />
     </Layout>
   );
 }

--- a/src/pages/profile/mygithub/index.tsx
+++ b/src/pages/profile/mygithub/index.tsx
@@ -4,8 +4,8 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import Layout from '@/components/common/Layout';
 import BottomFixedBtn from '@/components/common/BottomFixedBtn';
-import Portal from '@/components/modal/ModalPortal';
 import Modal from '@/components/modal/Modal';
+import useModal from '@/hooks/useModal';
 
 interface IGithub {
   githubId: string;
@@ -14,9 +14,7 @@ interface IGithub {
 
 export default function MyGithub() {
   const router = useRouter();
-  const [isModalOpen, setModalOpen] = useState(false);
-  const openModal = () => setModalOpen(true);
-  const closeModal = () => setModalOpen(false);
+  const { openModal, closeModal } = useModal();
   const [githubData, setGithubData] = useState<IGithub>({
     githubId: 'hello_world',
     githubToken: '12345678',
@@ -122,23 +120,22 @@ export default function MyGithub() {
               styleType: 'primary',
               size: 'large',
               type: isGithubLinked ? 'button' : 'submit',
-              onClick: isGithubLinked ? openModal : undefined,
+              onClick: isGithubLinked
+                ? () =>
+                    openModal({
+                      image: '/icons/icon-exclamation-mark.svg',
+                      mainText: '정말 연동을 해지하시겠습니까?',
+                      subText:
+                        '연동을 해지하면, 현재 깃허브 챌린지를 참가하고 있을 경우 중도 포기로 간주됩니다.',
+                      btnText: '네, 해지할게요',
+                      onClick: clickModalBtn,
+                    })
+                : undefined,
             },
           ]}
         />
       </SMyGithubWrapper>
-      {isModalOpen && (
-        <Portal>
-          <Modal
-            image="/icons/icon-exclamation-mark.svg"
-            mainText="정말 연동을 해지하시겠습니까?"
-            subText="연동을 해지하면, 현재 깃허브 챌린지를 참가하고 있을 경우 중도 포기로 간주됩니다."
-            btnText="네, 해지할게요"
-            onClick={clickModalBtn}
-            onClose={closeModal}
-          />
-        </Portal>
-      )}
+      <Modal />
     </Layout>
   );
 }

--- a/src/pages/profile/myreview/index.tsx
+++ b/src/pages/profile/myreview/index.tsx
@@ -8,6 +8,7 @@ import SnackBar from '@/components/common/SnackBar';
 import EmptyView from '@/components/common/EmptyView';
 import ISnackBarState from '@/types/snackbar';
 import REVIEW_SNACKBAR_TEXT from '@/constants/reviewSnackBarText';
+import Modal from '@/components/modal/Modal';
 
 export default function MyReview({
   getMyReviews,
@@ -86,6 +87,7 @@ export default function MyReview({
           noFooter
         />
       )}
+      <Modal />
     </Layout>
   );
 }

--- a/src/pages/verification/collection/[groupId].tsx
+++ b/src/pages/verification/collection/[groupId].tsx
@@ -176,7 +176,7 @@ export default function VeirificationCollection({
     if (query.submitVerification) {
       handleRouting('인증 제출이 완료되었습니다.');
     }
-  }, [query, router, groupId]);
+  }, [query, router, groupId, type]);
 
   return (
     <Layout

--- a/src/pages/verification/post/[groupId].tsx
+++ b/src/pages/verification/post/[groupId].tsx
@@ -6,7 +6,6 @@ import WriteLayout, { TPageType } from '@/components/common/WriteLayout';
 import writeLayoutText from '@/constants/writeLayoutText';
 import PhotoInput from '@/components/verification/post/PhotoInput';
 import TextArea from '@/components/common/TextArea';
-import Portal from '@/components/modal/ModalPortal';
 import Modal from '@/components/modal/Modal';
 import LinkInput from '@/components/verification/post/LinkInput';
 import VERIFICATION_TYPE from '@/constants/verificationType';
@@ -87,9 +86,7 @@ export default function VerificationPost() {
           </>
         )}
       </WriteLayout>
-      <Portal>
-        <Modal />
-      </Portal>
+      <Modal />
     </Layout>
   );
 }

--- a/src/pages/verification/post/[groupId].tsx
+++ b/src/pages/verification/post/[groupId].tsx
@@ -32,9 +32,6 @@ export default function VerificationPost() {
   const [isLinkValid, setIsLinkaValid] = useState<boolean | undefined>(
     undefined,
   );
-  const [isModalOpen, setModalOpen] = useState(false);
-  const openModal = () => setModalOpen(true);
-  const closeModal = () => setModalOpen(false);
 
   const handleSubmit = (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
@@ -70,7 +67,7 @@ export default function VerificationPost() {
         text={text}
         file={file}
         isLinkValid={isLinkValid}
-        onClick={openModal}
+        onClick={handleSubmit}
       >
         {verificationType === 'TEXT' && (
           <>
@@ -90,18 +87,9 @@ export default function VerificationPost() {
           </>
         )}
       </WriteLayout>
-      {isModalOpen && (
-        <Portal>
-          <Modal
-            image="/icons/icon-exclamation-mark.svg"
-            mainText="인증을 제출 하시겠습니까?"
-            subText="인증하기 제출 후 수정, 삭제할 수 없으니 확인 후 올려주시기 바랍니다."
-            btnText="제출하기"
-            onClick={handleSubmit}
-            onClose={closeModal}
-          />
-        </Portal>
-      )}
+      <Portal>
+        <Modal />
+      </Portal>
     </Layout>
   );
 }

--- a/src/types/modal.ts
+++ b/src/types/modal.ts
@@ -1,0 +1,12 @@
+export interface IModal {
+  mainText: string;
+  subText?: string;
+  image?: string;
+  btnText: string;
+  cancelBtnText?: string;
+  onClick: (e: React.MouseEvent<HTMLElement>) => void;
+}
+
+export interface IModalState extends IModal {
+  isOpen: boolean;
+}

--- a/src/types/myChallenge.ts
+++ b/src/types/myChallenge.ts
@@ -9,9 +9,11 @@ export type TMyChallengeInfo = {
   successCount: number;
   isReviewed?: boolean | null;
   isVerified?: boolean | null;
+  isRefunded?: boolean | null;
+  isSuccessed?: boolean | null;
   isGithubConnected?: boolean;
   verificationType: TVerificationType;
   deposit: number;
 };
 
-export type TMyChallengeStatus = 'progress' | 'waiting' | 'completed';
+export type TMyChallengeStatus = 'PROGRESS' | 'WAITING' | 'COMPLETED';


### PR DESCRIPTION
close #50

## ✨ 구현 기능 명세
마이챌린지 진행완료 섹션 디자인 수정사항 반영 

-  달성완료/달성실패/환급완료 라벨 구현
-  달성완료한 챌린지만 환급신청 버튼
-  환급신청완료한 경우 후기작성 버튼
-  환급신청완료 모달
-  날짜형식 변경
-  모달 전역상태로 관리하도록 타입 및 컴포넌트내용 변경

## 🎁 PR Point
같은 페이지내에서 버튼에 따라 다른 모달을 띄워야하는 상황이라 기존의 모달컴포넌트를 해당 상황에 사용하기 위해선 모달컴포넌트를 페이지컴포넌트 내에서 두개를 호출하고 모달을 여닫는 상태도 두개만들어야하는 상황이었습니다. 또한 모달을 여닫는 set함수를 과하게 드릴링해야하는 상황이었어서 이점이 비효율적으로 느껴져 모달관리를 전역상태로 분리하여 관리하도록 구현하였습니다. 기재해둔 모달 사용법을 참고해주세요.

```ts
const { openModal,closeModal } = useModal();
...
  <SBtn
    ...
    onClick={() =>
      openModal({
        image: '/icons/icon-exclamation-mark.svg',
        mainText: '인증을 제출 하시겠습니까?',
        subText:
          '인증하기 제출 후 수정, 삭제할 수 없으니 확인 후 올려주시기 바랍니다.',
        btnText: '제출하기',
        onClick: () => {
          console.log('인증제출하기');
          closeModal();
        },
      })
    }
  >
```
-> 모달을 오픈하는 코드
⚠️ 모달 내 취소버튼이 아닌 동작이 필요한 버튼클릭이벤트 함수 마지막에 closeModal을 넣어주셔야합니다. 모달 오픈상태가 전역으로 관리되고있기때문에 closeModal() 동작이 없으면 뒤로가기시 모달이 그대로 열려있어요!

```ts
<Layout>
...
  <Modal />
</Layout>
```
-> 모달이 오픈되어야하는 페이지컴포넌트에 모달컴포넌트 호출

[`hooks/useModal.ts`](https://github.com/Senity-Waved/Waved_FE/blob/feature/%2350/src/hooks/useModal.ts)
[`atoms/modal.ts`](https://github.com/Senity-Waved/Waved_FE/blob/feature/%2350/src/atoms/modal.ts)

## 🕰 소요시간
4h

## 🙏 비고
전역상태로 관리되는 모달컴포넌트를 제가 작업중이던 페이지에만 적용한 상태라 기존의 모달을 사용중인 다른 페이지에서 에러가 발생할것같습니다. 코드 확인해주시고 이상없으시면 제가 기존의 모달코드부분들의 바꿔둘게요!

<!-- (선택) -->
