### PR TITLE
[#65][FEATURE] 챌린지 후기 기능 구현 및 나의 후기 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-indiana-drag-scroll": "^2.2.0",
+        "react-intersection-observer": "^9.8.1",
         "react-slick": "^0.30.2",
         "react-spinners": "^0.13.8",
         "recoil": "^0.7.7",
@@ -4293,6 +4294,20 @@
       "peerDependencies": {
         "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.8.1.tgz",
+      "integrity": "sha512-QzOFdROX8D8MH3wE3OVKH0f3mLjKTtEN1VX/rkNuECCff+aKky0pIjulDhr3Ewqj5el/L+MhBkM3ef0Tbt+qUQ==",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-indiana-drag-scroll": "^2.2.0",
+    "react-intersection-observer": "^9.8.1",
     "react-slick": "^0.30.2",
     "react-spinners": "^0.13.8",
     "recoil": "^0.7.7",

--- a/src/components/challenge/ChallengeReviewItem.tsx
+++ b/src/components/challenge/ChallengeReviewItem.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { TChallengeReview } from '@/types/review';
 import parseDate from '@/utils/parseDate';
 import { JOB_TITLE_KR } from '@/constants/jobTitle';
+import formattedFormText from '@/utils/formattedFormText';
 
 const formattedDate = (date: string) => {
   const [year, month, day] = parseDate(date);
@@ -21,7 +22,7 @@ export default function ChallengeReviewItem({
         {jobTitle && <SJobTitle>{JOB_TITLE_KR[jobTitle]}</SJobTitle>}
         <SDate>{formattedDate(createDate)}</SDate>
       </SReviewInfo>
-      <SReviewContent>{content}</SReviewContent>
+      <SReviewContent>{formattedFormText(content)}</SReviewContent>
     </SReviewItem>
   );
 }
@@ -77,6 +78,7 @@ const SDate = styled.span`
 `;
 
 const SReviewContent = styled.p`
+  white-space: pre-line;
   color: ${({ theme }) => theme.color.gray_3c};
   font-size: ${({ theme }) => theme.fontSize.body4};
   font-weight: ${({ theme }) => theme.fontWeight.body4};

--- a/src/components/challenge/ParticipantButton.tsx
+++ b/src/components/challenge/ParticipantButton.tsx
@@ -85,7 +85,12 @@ export default function ParticipantButton({
     const handleClick = () => {
       if (!isLogined && dDayToStart <= 14 && dDayToStart >= 1) {
         goToOnboarding();
-      } else if (isLogined && !isApplied && dDayToStart <= 14) {
+      } else if (
+        isLogined &&
+        !isApplied &&
+        dDayToStart <= 14 &&
+        dDayToStart >= 1
+      ) {
         goToParticipant();
       } else if (isApplied && dDayToStart <= 14 && dDayToStart >= 1) {
         openModal({
@@ -129,8 +134,8 @@ export default function ParticipantButton({
       });
     } else if (dDayToStart < 1) {
       setBtnConfig({
-        text: '마감이지만 테스트를 위해 신청 허용',
-        styleType: 'primary',
+        text: '마감',
+        styleType: 'disabled',
         size: 'large',
         onClick: handleClick,
       });

--- a/src/components/challenge/ParticipantButton.tsx
+++ b/src/components/challenge/ParticipantButton.tsx
@@ -85,12 +85,7 @@ export default function ParticipantButton({
     const handleClick = () => {
       if (!isLogined && dDayToStart <= 14 && dDayToStart >= 1) {
         goToOnboarding();
-      } else if (
-        isLogined &&
-        !isApplied &&
-        dDayToStart <= 14 &&
-        dDayToStart >= 1
-      ) {
+      } else if (isLogined && !isApplied && dDayToStart <= 14) {
         goToParticipant();
       } else if (isApplied && dDayToStart <= 14 && dDayToStart >= 1) {
         openModal({
@@ -134,9 +129,10 @@ export default function ParticipantButton({
       });
     } else if (dDayToStart < 1) {
       setBtnConfig({
-        text: '마감',
-        styleType: 'disabled',
+        text: '마감이지만 테스트를 위해 신청 허용',
+        styleType: 'primary',
         size: 'large',
+        onClick: handleClick,
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/mychallenge/ChallengeBtn.tsx
+++ b/src/components/mychallenge/ChallengeBtn.tsx
@@ -170,10 +170,8 @@ export default function ChallengeBtn({
           ) : (
             <SLink
               href={{
-                pathname: `/mychallenge/review`,
-                query: { challengeId: challengeGroupId },
+                pathname: `/mychallenge/review/${myChallengeId}`,
               }}
-              as="mychallenge/review"
             >
               <SBtn
                 styleType={isAble ? 'border' : 'bordergray'}

--- a/src/components/profile/myreview/MyReviewItem.tsx
+++ b/src/components/profile/myreview/MyReviewItem.tsx
@@ -1,13 +1,12 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
 import { TMyReview } from '@/types/review';
 import useModal from '@/hooks/useModal';
 import formattedFormText from '@/utils/formattedFormText';
 import parseDate from '@/utils/parseDate';
-
-interface IMyReviewItem extends TMyReview {
-  onDelete: () => void;
-}
+import { deleteReviewApi } from '@/lib/axios/review/api';
 
 const formattedDate = (date: string) => {
   const [year, month, day] = parseDate(date);
@@ -19,9 +18,28 @@ export default function MyReviewItem({
   groupTitle,
   createDate,
   content,
-  onDelete,
-}: IMyReviewItem) {
+}: TMyReview) {
+  const router = useRouter();
   const { openModal, closeModal } = useModal();
+  const { mutate: deleteReview } = useMutation(
+    () => deleteReviewApi(reviewId),
+    {
+      onSuccess: () => {
+        console.log(`${reviewId} 삭제완료!`);
+        router
+          .push({
+            pathname: '/profile/myreview',
+            query: {
+              deleteReviewSuccess: true,
+            },
+          })
+          .catch((error) => console.error('페이지 이동 실패', error));
+      },
+      onError: (error) => {
+        console.error('리뷰 삭제 실패', error);
+      },
+    },
+  );
   return (
     <SMyReviewItem>
       <STitleWrapper>
@@ -45,7 +63,7 @@ export default function MyReviewItem({
               mainText: '남기신 후기를 삭제하시겠습니까?',
               btnText: '삭제하기',
               onClick: () => {
-                onDelete();
+                deleteReview();
                 closeModal();
               },
             })

--- a/src/components/profile/myreview/MyReviewItem.tsx
+++ b/src/components/profile/myreview/MyReviewItem.tsx
@@ -1,32 +1,32 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
-import IMyReview from '@/types/myReview';
+import { TMyReview } from '@/types/review';
 import useModal from '@/hooks/useModal';
 
-interface IMyReviewItem extends IMyReview {
+interface IMyReviewItem extends TMyReview {
   onDelete: () => void;
 }
 
 export default function MyReviewItem({
-  id,
-  challengeTitle,
-  createdDate,
-  context,
+  reviewId,
+  groupTitle,
+  createDate,
+  content,
   onDelete,
 }: IMyReviewItem) {
   const { openModal, closeModal } = useModal();
   return (
     <SMyReviewItem>
       <STitleWrapper>
-        <STitle>{challengeTitle}</STitle>
-        <SDate>{createdDate}</SDate>
+        <STitle>{groupTitle}</STitle>
+        <SDate>{createDate}</SDate>
       </STitleWrapper>
-      <SContext>{context}</SContext>
+      <SContext>{content}</SContext>
       <SBtnWrapper>
         <SEditBtn
           href={{
             pathname: `/profile/myreview/edit`,
-            query: { context, reviewId: id },
+            query: { content, reviewId },
           }}
           as="myreview/edit"
         >

--- a/src/components/profile/myreview/MyReviewItem.tsx
+++ b/src/components/profile/myreview/MyReviewItem.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import Link from 'next/link';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { TMyReview } from '@/types/review';
 import useModal from '@/hooks/useModal';
@@ -20,12 +20,16 @@ export default function MyReviewItem({
   content,
 }: TMyReview) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { openModal, closeModal } = useModal();
   const { mutate: deleteReview } = useMutation(
     () => deleteReviewApi(reviewId),
     {
       onSuccess: () => {
         console.log(`${reviewId} 삭제완료!`);
+        queryClient
+          .invalidateQueries(['myReviews'])
+          .catch((error) => console.error('쿼리 초기화 실패', error));
         router
           .push({
             pathname: '/profile/myreview',

--- a/src/components/profile/myreview/MyReviewItem.tsx
+++ b/src/components/profile/myreview/MyReviewItem.tsx
@@ -2,10 +2,17 @@ import styled from '@emotion/styled';
 import Link from 'next/link';
 import { TMyReview } from '@/types/review';
 import useModal from '@/hooks/useModal';
+import formattedFormText from '@/utils/formattedFormText';
+import parseDate from '@/utils/parseDate';
 
 interface IMyReviewItem extends TMyReview {
   onDelete: () => void;
 }
+
+const formattedDate = (date: string) => {
+  const [year, month, day] = parseDate(date);
+  return `${year}년 ${month}월 ${day}일`;
+};
 
 export default function MyReviewItem({
   reviewId,
@@ -19,16 +26,15 @@ export default function MyReviewItem({
     <SMyReviewItem>
       <STitleWrapper>
         <STitle>{groupTitle}</STitle>
-        <SDate>{createDate}</SDate>
+        <SDate>{formattedDate(createDate)}</SDate>
       </STitleWrapper>
-      <SContext>{content}</SContext>
+      <SContext>{formattedFormText(content)}</SContext>
       <SBtnWrapper>
         <SEditBtn
           href={{
             pathname: `/profile/myreview/edit`,
-            query: { content, reviewId },
+            query: { reviewId },
           }}
-          as="myreview/edit"
         >
           수정
         </SEditBtn>

--- a/src/lib/axios/challenge/api.ts
+++ b/src/lib/axios/challenge/api.ts
@@ -1,7 +1,7 @@
 import { AxiosInstance } from 'axios';
 import IChallengeGroup from '@/types/challengeGroup';
 import axiosInstance from '../instance';
-import { IReviewList } from '@/types/review';
+import { IChallengeReviewList } from '@/types/review';
 
 /**
  * 챌린지 그룹 정보 GET
@@ -24,7 +24,7 @@ const getChallengeGroupApi = (
  * @returns response.data
  */
 const getReviewsApi = (challengeId: number, serverInstance: AxiosInstance) => {
-  return serverInstance.get<IReviewList>(
+  return serverInstance.get<IChallengeReviewList>(
     `/challenges/${challengeId}/reviews?page=0&limit=5`,
   );
 };

--- a/src/lib/axios/challenge/api.ts
+++ b/src/lib/axios/challenge/api.ts
@@ -19,13 +19,26 @@ const getChallengeGroupApi = (
 };
 
 /**
- * 리뷰 목록 조회 GET
+ * 리뷰 목록 최초 조회 GET
  * @param challengeId
  * @returns response.data
  */
 const getReviewsApi = (challengeId: number, serverInstance: AxiosInstance) => {
   return serverInstance.get<IChallengeReviewList>(
     `/challenges/${challengeId}/reviews?page=0&limit=5`,
+  );
+};
+
+/**
+ * 리뷰 목록 추가 조회 GET
+ * @param pageParam
+ * @param challengeId
+ * @returns response.data
+ */
+
+const getMoreReviewsApi = (pageParam: number, challengeId: number) => {
+  return axiosInstance.get<IChallengeReviewList>(
+    `/challenges/${challengeId}/reviews?page=${pageParam}&limit=5`,
   );
 };
 
@@ -38,4 +51,9 @@ const deleteMyChallengeApi = (myChallengeId: number) => {
   return axiosInstance.delete(`/myChallenges/${myChallengeId}/delete`);
 };
 
-export { getChallengeGroupApi, getReviewsApi, deleteMyChallengeApi };
+export {
+  getChallengeGroupApi,
+  getReviewsApi,
+  getMoreReviewsApi,
+  deleteMyChallengeApi,
+};

--- a/src/lib/axios/mychallenge/api.ts
+++ b/src/lib/axios/mychallenge/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { CookieValueTypes } from 'cookies-next';
 import { TMyChallengeInfo } from '@/types/myChallenge';
+import axiosInstance from '../instance';
 
 export const fetchMyChallenges = async (
   status: string,
@@ -23,3 +24,12 @@ export const fetchMyChallenges = async (
 };
 
 export default fetchMyChallenges;
+
+/**
+ * 후기 작성 POST
+ * @param myChallengeId
+ * @returns response.data
+ */
+export const postMyReviewApi = (myChallengeId: string, content: string) => {
+  return axiosInstance.post(`/reviews/myChallenge/${myChallengeId}`, content);
+};

--- a/src/lib/axios/mychallenge/api.ts
+++ b/src/lib/axios/mychallenge/api.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { CookieValueTypes } from 'cookies-next';
 import { TMyChallengeInfo } from '@/types/myChallenge';
-import axiosInstance from '../instance';
 
 export const fetchMyChallenges = async (
   status: string,
@@ -24,12 +23,3 @@ export const fetchMyChallenges = async (
 };
 
 export default fetchMyChallenges;
-
-/**
- * 후기 작성 POST
- * @param myChallengeId
- * @returns response.data
- */
-export const postMyReviewApi = (myChallengeId: string, content: string) => {
-  return axiosInstance.post(`/reviews/myChallenge/${myChallengeId}`, content);
-};

--- a/src/lib/axios/review/api.ts
+++ b/src/lib/axios/review/api.ts
@@ -1,10 +1,11 @@
+import { AxiosInstance } from 'axios';
 import { IMyReviewList } from '@/types/review';
 import axiosInstance from '../instance';
 
 /**
  * 후기 작성 POST
- * @param myChallengeId
- * @returns response.data
+ * @param myChallengeId, content
+ * @returns message (성공: '리뷰를 작성했습니다')
  */
 const postReviewApi = (myChallengeId: string, content: string) => {
   return axiosInstance.post(`/reviews/myChallenge/${myChallengeId}`, content);
@@ -12,6 +13,7 @@ const postReviewApi = (myChallengeId: string, content: string) => {
 
 /**
  * 내가 작성한 후기 목록 조회 GET
+ * @param pageParam
  * @returns response.data
  */
 const getMyReviewsApi = (pageParam: number) => {
@@ -25,8 +27,11 @@ const getMyReviewsApi = (pageParam: number) => {
  * @param reviewId
  * @returns content
  */
-const getPrevReviewContentApi = (reviewId: number) => {
-  return axiosInstance.get<IMyReviewList[]>(`/reviews/${reviewId}`);
+const getPreviousReviewContentApi = (
+  serverInstance: AxiosInstance,
+  reviewId: string,
+) => {
+  return serverInstance.get<string>(`/reviews/${reviewId}`);
 };
 
 /**
@@ -34,7 +39,7 @@ const getPrevReviewContentApi = (reviewId: number) => {
  * @param reviewId, content
  * @returns message (성공: '리뷰를 수정했습니다')
  */
-const patchReviewApi = (reviewId: number, content: string) => {
+const patchReviewApi = (reviewId: string, content: string) => {
   return axiosInstance.patch(`/reviews/${reviewId}`, content);
 };
 
@@ -50,7 +55,7 @@ const deleteReviewApi = (reviewId: number) => {
 export {
   postReviewApi,
   getMyReviewsApi,
-  getPrevReviewContentApi,
+  getPreviousReviewContentApi,
   patchReviewApi,
   deleteReviewApi,
 };

--- a/src/lib/axios/review/api.ts
+++ b/src/lib/axios/review/api.ts
@@ -11,12 +11,12 @@ const postReviewApi = (myChallengeId: string, content: string) => {
 };
 
 /**
- * 내가 작성한 후기 목록 GET
+ * 내가 작성한 후기 목록 조회 GET
  * @returns response.data
  */
 const getMyReviewsApi = (pageParam: number) => {
-  return axiosInstance.get<IMyReviewList[]>(
-    `/members/review?page=${pageParam}&limit=5`,
+  return axiosInstance.get<IMyReviewList>(
+    `/members/reviews?page=${pageParam}&limit=5`,
   );
 };
 

--- a/src/lib/axios/review/api.ts
+++ b/src/lib/axios/review/api.ts
@@ -1,0 +1,56 @@
+import { IMyReviewList } from '@/types/review';
+import axiosInstance from '../instance';
+
+/**
+ * 후기 작성 POST
+ * @param myChallengeId
+ * @returns response.data
+ */
+const postReviewApi = (myChallengeId: string, content: string) => {
+  return axiosInstance.post(`/reviews/myChallenge/${myChallengeId}`, content);
+};
+
+/**
+ * 내가 작성한 후기 목록 GET
+ * @returns response.data
+ */
+const getMyReviewsApi = (pageParam: number) => {
+  return axiosInstance.get<IMyReviewList[]>(
+    `/members/review?page=${pageParam}&limit=5`,
+  );
+};
+
+/**
+ * 이전에 작성한 후기의 내용 GET
+ * @param reviewId
+ * @returns content
+ */
+const getPrevReviewContentApi = (reviewId: number) => {
+  return axiosInstance.get<IMyReviewList[]>(`/reviews/${reviewId}`);
+};
+
+/**
+ * 후기 수정 PATCH
+ * @param reviewId, content
+ * @returns message (성공: '리뷰를 수정했습니다')
+ */
+const patchReviewApi = (reviewId: number, content: string) => {
+  return axiosInstance.patch(`/reviews/${reviewId}`, content);
+};
+
+/**
+ * 후기 삭제 DELETE
+ * @param reviewId
+ * @returns message (성공: '리뷰를 삭제했습니다')
+ */
+const deleteReviewApi = (reviewId: number) => {
+  return axiosInstance.delete(`/reviews/${reviewId}`);
+};
+
+export {
+  postReviewApi,
+  getMyReviewsApi,
+  getPrevReviewContentApi,
+  patchReviewApi,
+  deleteReviewApi,
+};

--- a/src/pages/challenge/[groupId].tsx
+++ b/src/pages/challenge/[groupId].tsx
@@ -21,7 +21,7 @@ import getChallengeThumbnailPath from '@/utils/getChallengeThumbnailPath';
 import VeirificationExample from '@/components/challenge/VerificationExample';
 import VERIFICATION_TYPE from '@/constants/verificationType';
 import IChallengeGroup from '@/types/challengeGroup';
-import { IReviewList, TChallengeReview } from '@/types/review';
+import { IChallengeReviewList, TChallengeReview } from '@/types/review';
 import parseDate from '@/utils/parseDate';
 import WEEKDAYS from '@/constants/weekdays';
 import calculateDDay from '@/utils/calculateDDay';
@@ -67,7 +67,7 @@ export default function Challenge({
   reviewList,
 }: {
   challengeInfo: IChallengeGroup;
-  reviewList: IReviewList;
+  reviewList: IChallengeReviewList;
 }) {
   const router = useRouter();
   const groupId = router.query.groupId as string;
@@ -94,7 +94,7 @@ export default function Challenge({
   const fetchMoreReviews = async ({
     pageParam = 0,
   }): Promise<IFetchMoreReviewsResponse> => {
-    const response = await axios.get<IReviewList>(
+    const response = await axios.get<IChallengeReviewList>(
       `${process.env.NEXT_PUBLIC_BASE_URL}/challenges/${challengeInfo.challengeId}/reviews?page=${pageParam}&limit=5`,
     );
     return {
@@ -262,7 +262,7 @@ export async function getServerSideProps(
   | {
       props: {
         challengeInfo: IChallengeGroup;
-        reviewList: IReviewList;
+        reviewList: IChallengeReviewList;
       };
     }
   | { notFound: true }

--- a/src/pages/mychallenge/review/[myChallengeId].tsx
+++ b/src/pages/mychallenge/review/[myChallengeId].tsx
@@ -7,13 +7,13 @@ import TextArea from '@/components/common/TextArea';
 
 export default function PostReview() {
   const router = useRouter();
-  const challengeId = router.query.challengeId as string;
+  const mychallengeId = router.query.myChallengeId as string;
   const { placeholder } = writeLayoutText['후기작성'];
   const [text, setText] = useState<string>('');
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(`${challengeId}의 리뷰 작성 완료! : ${text}`);
+    console.log(`${mychallengeId}의 리뷰 작성 완료! : ${text}`);
     router
       .push({
         pathname: '/mychallenge',

--- a/src/pages/mychallenge/review/[myChallengeId].tsx
+++ b/src/pages/mychallenge/review/[myChallengeId].tsx
@@ -4,7 +4,7 @@ import Layout from '@/components/common/Layout';
 import WriteLayout from '@/components/common/WriteLayout';
 import writeLayoutText from '@/constants/writeLayoutText';
 import TextArea from '@/components/common/TextArea';
-import { postMyReviewApi } from '@/lib/axios/mychallenge/api';
+import { postReviewApi } from '@/lib/axios/review/api';
 
 export default function PostReview() {
   const router = useRouter();
@@ -14,7 +14,7 @@ export default function PostReview() {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    postMyReviewApi(myChallengeId, text)
+    postReviewApi(myChallengeId, text)
       .then((response) => {
         if (response) {
           console.log(`${myChallengeId}의 리뷰 작성 완료! : ${text}`);

--- a/src/pages/mychallenge/review/[myChallengeId].tsx
+++ b/src/pages/mychallenge/review/[myChallengeId].tsx
@@ -4,26 +4,33 @@ import Layout from '@/components/common/Layout';
 import WriteLayout from '@/components/common/WriteLayout';
 import writeLayoutText from '@/constants/writeLayoutText';
 import TextArea from '@/components/common/TextArea';
+import { postMyReviewApi } from '@/lib/axios/mychallenge/api';
 
 export default function PostReview() {
   const router = useRouter();
-  const mychallengeId = router.query.myChallengeId as string;
+  const myChallengeId = router.query.myChallengeId as string;
   const { placeholder } = writeLayoutText['후기작성'];
   const [text, setText] = useState<string>('');
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(`${mychallengeId}의 리뷰 작성 완료! : ${text}`);
-    router
-      .push({
-        pathname: '/mychallenge',
-        query: {
-          postReviewSuccess: true,
-        },
+    postMyReviewApi(myChallengeId, text)
+      .then((response) => {
+        if (response) {
+          console.log(`${myChallengeId}의 리뷰 작성 완료! : ${text}`);
+          router
+            .push({
+              pathname: '/mychallenge',
+              query: {
+                postReviewSuccess: true,
+              },
+            })
+            .catch((error) => console.error(error));
+        }
       })
-      .catch((error) => {
-        console.error('페이지 이동 실패', error);
-      });
+      .catch((error) =>
+        console.error(`${myChallengeId}의 리뷰 작성 실패`, error),
+      );
   };
 
   return (

--- a/src/pages/profile/myreview/edit/index.tsx
+++ b/src/pages/profile/myreview/edit/index.tsx
@@ -1,32 +1,46 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
+import { useMutation } from '@tanstack/react-query';
+import { GetServerSidePropsContext } from 'next';
 import Layout from '@/components/common/Layout';
 import WriteLayout from '@/components/common/WriteLayout';
 import TextArea from '@/components/common/TextArea';
 import writeLayoutText from '@/constants/writeLayoutText';
+import {
+  getPreviousReviewContentApi,
+  patchReviewApi,
+} from '@/lib/axios/review/api';
+import createServerInstance from '@/lib/axios/serverInstance';
 
-export default function EditReview() {
+export default function EditReview({ prevContent }: { prevContent: string }) {
   const router = useRouter();
   const reviewId = router.query.reviewId as string;
-  const context = router.query.context as string;
   const { placeholder } = writeLayoutText['후기수정'];
-  const [text, setText] = useState<string>(
-    typeof context === 'string' ? context : '',
+  const [text, setText] = useState<string>(prevContent);
+
+  const { mutate: patchReview } = useMutation(
+    (newContent: string) => patchReviewApi(reviewId, newContent),
+    {
+      onSuccess: () => {
+        console.log(`${reviewId} 수정완료! : ${text}`);
+        router
+          .push({
+            pathname: '/profile/myreview',
+            query: {
+              editReviewSuccess: true,
+            },
+          })
+          .catch((error) => console.error('페이지 이동 실패', error));
+      },
+      onError: (error) => {
+        console.error('리뷰 수정 실패', error);
+      },
+    },
   );
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    console.log(`${reviewId} 수정완료! : ${text}`);
-    router
-      .push({
-        pathname: '/profile/myreview',
-        query: {
-          editReviewSuccess: true,
-        },
-      })
-      .catch((error) => {
-        console.error('페이지 이동 실패', error);
-      });
+    patchReview(text);
   };
 
   return (
@@ -41,4 +55,30 @@ export default function EditReview() {
       </WriteLayout>
     </Layout>
   );
+}
+
+export async function getServerSideProps(
+  context: GetServerSidePropsContext,
+): Promise<{
+  props: {
+    prevContent: string;
+  };
+}> {
+  const { reviewId } = context.query as { reviewId: string };
+  const serverInstance = createServerInstance(context);
+  let prevContent = '';
+  try {
+    const response = await getPreviousReviewContentApi(
+      serverInstance,
+      reviewId,
+    );
+    prevContent = response.data;
+  } catch (error) {
+    console.error('이전 리뷰 데이터 가져오기 실패', error);
+  }
+  return {
+    props: {
+      prevContent,
+    },
+  };
 }

--- a/src/pages/profile/myreview/index.tsx
+++ b/src/pages/profile/myreview/index.tsx
@@ -13,7 +13,7 @@ import Modal from '@/components/modal/Modal';
 import { getMyReviewsApi } from '@/lib/axios/review/api';
 import { IMyReviewList } from '@/types/review';
 
-interface IFetchMoreReviewsResponse extends IMyReviewList {
+export interface IFetchMoreReviewsResponse extends IMyReviewList {
   nextPage: number;
 }
 

--- a/src/pages/profile/myreview/index.tsx
+++ b/src/pages/profile/myreview/index.tsx
@@ -55,20 +55,6 @@ export default function MyReview() {
     }
   };
 
-  const deleteReview = (reviewId: number) => {
-    console.log(`삭제완료! ${reviewId}`);
-    setSnackBarState({
-      open: true,
-      text: REVIEW_SNACKBAR_TEXT.DELETE,
-    });
-    setTimeout(() => {
-      setSnackBarState({
-        open: false,
-        text: '',
-      });
-    }, 3500);
-  };
-
   useEffect(() => {
     const handleRouting = (
       snackBarText: string,
@@ -93,6 +79,8 @@ export default function MyReview() {
     };
     if (query.editReviewSuccess) {
       handleRouting(REVIEW_SNACKBAR_TEXT.EDIT);
+    } else if (query.deleteReviewSuccess) {
+      handleRouting(REVIEW_SNACKBAR_TEXT.DELETE);
     }
   }, [query, router]);
 
@@ -107,11 +95,7 @@ export default function MyReview() {
           {data.pages.map((page) => (
             <React.Fragment key={uuidv4()}>
               {page.content.map((review) => (
-                <MyReviewItem
-                  key={review.reviewId}
-                  {...review}
-                  onDelete={() => deleteReview(review.reviewId)}
-                />
+                <MyReviewItem key={review.reviewId} {...review} />
               ))}
             </React.Fragment>
           ))}

--- a/src/pages/profile/myreview/index.tsx
+++ b/src/pages/profile/myreview/index.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { v4 as uuidv4 } from 'uuid';
+import { useInView } from 'react-intersection-observer';
 import Layout from '@/components/common/Layout';
 import MyReviewItem from '@/components/profile/myreview/MyReviewItem';
 import SnackBar from '@/components/common/SnackBar';
@@ -36,6 +37,7 @@ export default function MyReview() {
     open: false,
     text: '',
   });
+  const [ref, inView] = useInView();
 
   const { data, isFetching, fetchNextPage, hasNextPage } = useInfiniteQuery<
     IFetchMoreReviewsResponse,
@@ -47,13 +49,19 @@ export default function MyReview() {
     },
   });
 
-  const handleReviewMore = () => {
+  const handleReviewMore = useCallback(() => {
     if (!isFetching && hasNextPage) {
       fetchNextPage().catch((error) => {
         console.error('리뷰 더보기 실패', error);
       });
     }
-  };
+  }, [isFetching, hasNextPage, fetchNextPage]);
+
+  useEffect(() => {
+    if (inView) {
+      handleReviewMore();
+    }
+  }, [inView, handleReviewMore]);
 
   useEffect(() => {
     const handleRouting = (
@@ -99,11 +107,7 @@ export default function MyReview() {
               ))}
             </React.Fragment>
           ))}
-          {hasNextPage && (
-            <button type="button" onClick={handleReviewMore}>
-              더보기
-            </button>
-          )}
+          {hasNextPage && <div ref={ref} style={{ height: '20px' }} />}
         </ul>
       )}
       {snackBarState.open && (

--- a/src/pages/profile/myreview/index.tsx
+++ b/src/pages/profile/myreview/index.tsx
@@ -17,6 +17,18 @@ interface IFetchMoreReviewsResponse extends IMyReviewList {
   nextPage: number;
 }
 
+const fetchMoreReviews = async ({
+  pageParam = 0,
+}): Promise<IFetchMoreReviewsResponse> => {
+  const response = await getMyReviewsApi(pageParam);
+  return {
+    content: response.data.content,
+    nextPage: pageParam + 1,
+    totalPages: response.data.totalPages,
+    totalElements: response.data.totalElements,
+  };
+};
+
 export default function MyReview() {
   const router = useRouter();
   const { query } = router;
@@ -25,17 +37,6 @@ export default function MyReview() {
     text: '',
   });
 
-  const fetchMoreReviews = async ({
-    pageParam = 0,
-  }): Promise<IFetchMoreReviewsResponse> => {
-    const response = await getMyReviewsApi(pageParam);
-    return {
-      content: response.data.content,
-      nextPage: pageParam + 1,
-      totalPages: response.data.totalPages,
-      totalElements: response.data.totalElements,
-    };
-  };
   const { data, isFetching, fetchNextPage, hasNextPage } = useInfiniteQuery<
     IFetchMoreReviewsResponse,
     Error

--- a/src/pages/profile/myreview/index.tsx
+++ b/src/pages/profile/myreview/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+import styled from '@emotion/styled';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { v4 as uuidv4 } from 'uuid';
 import Layout from '@/components/common/Layout';
@@ -96,8 +97,10 @@ export default function MyReview() {
 
   return (
     <Layout headerText="나의 후기" title="나의 후기" noFooter>
-      {!data || data.pages.length === 0 ? (
-        <EmptyView pageType="내후기" />
+      {!data || data.pages[0].totalElements === 0 ? (
+        <SEmptyViewWrapper>
+          <EmptyView pageType="내후기" />
+        </SEmptyViewWrapper>
       ) : (
         <ul>
           {data.pages.map((page) => (
@@ -129,3 +132,9 @@ export default function MyReview() {
     </Layout>
   );
 }
+
+const SEmptyViewWrapper = styled.div`
+  width: 100%;
+  min-height: 80vh;
+  height: auto;
+`;

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -1,6 +1,7 @@
 import TJobTitle from './jobTitle';
 
 interface IReview {
+  reviewId: number;
   challengeId: number;
   groupTitle: string;
   nickname: string;
@@ -9,7 +10,10 @@ interface IReview {
   content: string;
 }
 
-export type TMyReview = Pick<IReview, 'groupTitle' | 'createDate' | 'content'>;
+export type TMyReview = Pick<
+  IReview,
+  'reviewId' | 'groupTitle' | 'createDate' | 'content'
+>;
 
 export type TChallengeReview = Pick<
   IReview,

--- a/src/types/review.ts
+++ b/src/types/review.ts
@@ -1,9 +1,3 @@
-export interface IReviewList {
-  content: TChallengeReview[];
-  totalPages: number;
-  totalElements: number;
-}
-
 interface IReview {
   challengeId: number;
   groupTitle: string;
@@ -19,3 +13,15 @@ export type TChallengeReview = Pick<
   IReview,
   'nickname' | 'jobTitle' | 'createDate' | 'content'
 >;
+
+export interface IChallengeReviewList {
+  content: TChallengeReview[];
+  totalPages: number;
+  totalElements: number;
+}
+
+export interface IMyReviewList {
+  content: TMyReview[];
+  totalPages: number;
+  totalElements: number;
+}

--- a/src/utils/formattedFormText.ts
+++ b/src/utils/formattedFormText.ts
@@ -1,0 +1,8 @@
+const formattedFormText = (text: string) => {
+  return text
+    .slice(1, text.length - 1)
+    .replace(/\\"/g, '')
+    .replace(/\\n/g, ' ');
+};
+
+export default formattedFormText;


### PR DESCRIPTION
close #65 

<!-- PR의 제목은 "[#이슈번호][branch] 이슈이름" 으로 작성해주세요 -->

## ✨ 구현 기능 명세
- 챌린지 종료 후 후기 작성
- 챌린지 정보에서 후기 목록 렌더링
  - 후기 데이터 5개 이상일 경우 더보기 버튼을 이용한 추가 렌더링
- 나의 후기에서 후기 목록 렌더링
  - 후기 데이터가 5개 이상일 경우 무한 스크롤을 이용한 추가 렌더링
- 나의 후기에서 후기 수정
- 나의 후기에서 후기 삭제

## 🎁 PR Point
- 후기 관련 API 연동 작업 마무리 되었습니다. 작업 브랜치로 전환해서 확인하려는 경우, 기한이 지난 챌린지에 대해 참가 신청 버튼이 비활성화 되어 있어 테스트해보기 어려우실 것으로 판단됩니다. 테스트 필요 시 14cdcb 커밋을 참고하여 버튼을 임의로 활성화한 뒤 확인해보시길 권장 드립니다!
- client에서 api 연동 시 react-query를 적극 이용했습니다. 각 hook을 이용할 때 최대한 일관성 있게 사용하려고 신경썼는데 참고가 되었으면 합니다.
  - GET을 위한 `useQuery`
  - DELETE, PATCH를 위한 `useMutation`
  - 페이징처리된 API를 필요할 때 마다 차례로 호출하기 위한 `useInfinityQuery`
- 챌린지에 대한 후기는 더보기 버튼을 통해 5개씩 추가되고, 나의 후기는 react-intersection-observer를 이용하여 화면이 바닥에 닿을 때 5개씩 추가되도록 구현되어 있습니다. 예치금 내역에서도 동일한 방식 이용하셔도 괜찮을 것 같은데 참고 부탁드립니다!


## 🕰 소요시간
1d

## 😭 어려웠던 점
- react-query를 사용해본 적은 있으나 협업 경험의 부재로 (...) get을 위한 `useQuery` 경험만이 있었는데 이번 기회에 잘 모르더라도 사용해보자라는 마음으로 여러 훅을 사용해보았습니다. 최대한 깔끔하게 명시적으로 작성해보려 노력했는데 시간이 지나면 또 사용 방법은 잊어먹을 것 같아 걱정은 듭니다..ㅎ 그래도 의미있었습니다.
- 무한 스크롤 구현에 있어 탭 메뉴에서와 같이 IntersectionObserver API를 사용하려고 했으나 시간 관계상 더 빠른 방법을 채택하고자 라이브러리 이용했습니다. 익숙하지 않은 훅과 익숙하지 않은 API 구조에 어떤 식으로 호출해야 하는건지 감을 잡는데 큰 어려움을 겪으면서 시간을 많이 사용한 것 같아 아쉽기도 합니다. GET이라고 상대적으로 쉽게 생각했는데 오히려 다른 작업들 보다도 훨씬 큰 비중으로 고민했습니다.

<!-- (선택) -->
