### PR TITLE
[#75][FEATURE] 챌린지 신청 취소 API 연동

### DIFF
--- a/src/components/challenge/ParticipantButton.tsx
+++ b/src/components/challenge/ParticipantButton.tsx
@@ -7,10 +7,7 @@ import ISelectedChallenge from '@/types/selectedChallenge';
 import ASelectedChallenge from '@/atoms/selectedChallenge';
 import IChallengeGroup from '@/types/challengeGroup';
 import calculateDDay from '@/utils/calculateDDay';
-import {
-  deleteMyChallengeApi,
-  postRequestRefundApi,
-} from '@/lib/axios/challenge/api';
+import { postRequestRefundApi } from '@/lib/axios/challenge/api';
 import ISnackBarState from '@/types/snackbar';
 import useModal from '@/hooks/useModal';
 
@@ -64,28 +61,6 @@ export default function ParticipantButton({
       const refundResponse = await postRequestRefundApi(myChallengeId);
       if (refundResponse) {
         console.log('🧡 챌린지 환불 요청 성공', myChallengeId);
-        try {
-          const deleteResponse = await deleteMyChallengeApi(myChallengeId);
-          if (deleteResponse) {
-            console.log('💙 챌린지 신청 취소 요청 성공', myChallengeId);
-            router
-              .push({
-                pathname: `/challenge/${groupId}`,
-                query: {
-                  cancelParticipantSuccess: true,
-                },
-              })
-              .catch((error) => {
-                console.error('페이지 이동 실패', error);
-              });
-          }
-        } catch (refundError) {
-          console.error(
-            '💙 챌린지 신청 취소 요청 실패',
-            myChallengeId,
-            refundError,
-          );
-        }
       }
     } catch (deleteError) {
       console.error('🧡 챌린지 환불 요청 실패', myChallengeId, deleteError);

--- a/src/components/challenge/ParticipantButton.tsx
+++ b/src/components/challenge/ParticipantButton.tsx
@@ -85,12 +85,7 @@ export default function ParticipantButton({
     const handleClick = () => {
       if (!isLogined && dDayToStart <= 14 && dDayToStart >= 1) {
         goToOnboarding();
-      } else if (
-        isLogined &&
-        !isApplied &&
-        dDayToStart <= 14 &&
-        dDayToStart >= 1
-      ) {
+      } else if (isLogined && !isApplied && dDayToStart <= 14) {
         goToParticipant();
       } else if (isApplied && dDayToStart <= 14 && dDayToStart >= 1) {
         openModal({
@@ -134,8 +129,8 @@ export default function ParticipantButton({
       });
     } else if (dDayToStart < 1) {
       setBtnConfig({
-        text: '마감',
-        styleType: 'disabled',
+        text: '마감이지만 테스트를 위해 신청 허용',
+        styleType: 'primary',
         size: 'large',
         onClick: handleClick,
       });

--- a/src/components/challenge/ParticipantButton.tsx
+++ b/src/components/challenge/ParticipantButton.tsx
@@ -7,7 +7,7 @@ import ISelectedChallenge from '@/types/selectedChallenge';
 import ASelectedChallenge from '@/atoms/selectedChallenge';
 import IChallengeGroup from '@/types/challengeGroup';
 import calculateDDay from '@/utils/calculateDDay';
-import { postRequestRefundApi } from '@/lib/axios/challenge/api';
+import { postCancelParticipantApi } from '@/lib/axios/challenge/api';
 import ISnackBarState from '@/types/snackbar';
 import useModal from '@/hooks/useModal';
 
@@ -58,12 +58,24 @@ export default function ParticipantButton({
 
   const cancelParticipant = async () => {
     try {
-      const refundResponse = await postRequestRefundApi(myChallengeId);
-      if (refundResponse) {
-        console.log('🧡 챌린지 환불 요청 성공', myChallengeId);
+      const response = await postCancelParticipantApi(myChallengeId);
+      if (response) {
+        console.log('챌린지 취소 및 환불 요청 성공했습니다', myChallengeId);
+        router
+          .push({
+            pathname: `/challenge/${groupId}`,
+            query: {
+              cancelParticipantSuccess: true,
+            },
+          })
+          .catch((error) => console.error('페이지 이동 실패', error));
       }
     } catch (deleteError) {
-      console.error('🧡 챌린지 환불 요청 실패', myChallengeId, deleteError);
+      console.error(
+        '챌린지 취소 및 환불 요청 실패했습니다',
+        myChallengeId,
+        deleteError,
+      );
     }
   };
   const { openModal, closeModal } = useModal();

--- a/src/components/challenge/ParticipantButton.tsx
+++ b/src/components/challenge/ParticipantButton.tsx
@@ -7,7 +7,10 @@ import ISelectedChallenge from '@/types/selectedChallenge';
 import ASelectedChallenge from '@/atoms/selectedChallenge';
 import IChallengeGroup from '@/types/challengeGroup';
 import calculateDDay from '@/utils/calculateDDay';
-// import { deleteMyChallengeApi } from '@/lib/axios/challenge/api';
+import {
+  deleteMyChallengeApi,
+  postRequestRefundApi,
+} from '@/lib/axios/challenge/api';
 import ISnackBarState from '@/types/snackbar';
 import useModal from '@/hooks/useModal';
 
@@ -56,32 +59,37 @@ export default function ParticipantButton({
     });
   };
 
-  const cancelParticipant = () => {
-    // deleteMyChallengeApi(myChallengeId)
-    //   .then((response) => {
-    //     if (response) {
-    //       console.log('챌린지 신청 취소 요청 성공');
-    //       router.push({
-    //         pathname: `/challenge/${groupId}`,
-    //         query: {
-    //           cancelParticipantSuccess: true,
-    //         },
-    //       });
-    //     }
-    //   }).catch((error) => {
-    //     console.error('챌린지 신청 취소 요청 실패', error);
-    //   });
-    console.log('챌린지 신청 취소 요청 성공 | myChallengeId:', myChallengeId);
-    router
-      .push({
-        pathname: `/challenge/${groupId}`,
-        query: {
-          cancelParticipantSuccess: true,
-        },
-      })
-      .catch((error) => {
-        console.error('페이지 이동 실패', error);
-      });
+  const cancelParticipant = async () => {
+    try {
+      const refundResponse = await postRequestRefundApi(myChallengeId);
+      if (refundResponse) {
+        console.log('🧡 챌린지 환불 요청 성공', myChallengeId);
+        try {
+          const deleteResponse = await deleteMyChallengeApi(myChallengeId);
+          if (deleteResponse) {
+            console.log('💙 챌린지 신청 취소 요청 성공', myChallengeId);
+            router
+              .push({
+                pathname: `/challenge/${groupId}`,
+                query: {
+                  cancelParticipantSuccess: true,
+                },
+              })
+              .catch((error) => {
+                console.error('페이지 이동 실패', error);
+              });
+          }
+        } catch (refundError) {
+          console.error(
+            '💙 챌린지 신청 취소 요청 실패',
+            myChallengeId,
+            refundError,
+          );
+        }
+      }
+    } catch (deleteError) {
+      console.error('🧡 챌린지 환불 요청 실패', myChallengeId, deleteError);
+    }
   };
   const { openModal, closeModal } = useModal();
 
@@ -104,7 +112,7 @@ export default function ParticipantButton({
             '추가하신 예치금은 100% 환불이 가능하며, 카드사 사정에 따라 영업일 기준 평균 2~5일 이내 처리됩니다',
           btnText: '네, 취소할게요',
           onClick: () => {
-            cancelParticipant();
+            cancelParticipant().catch((error) => console.log(error));
             closeModal();
           },
         });

--- a/src/lib/axios/challenge/api.ts
+++ b/src/lib/axios/challenge/api.ts
@@ -51,9 +51,19 @@ const deleteMyChallengeApi = (myChallengeId: number) => {
   return axiosInstance.delete(`/myChallenges/${myChallengeId}/delete`);
 };
 
+/**
+ * 챌린지 신청 취소 환급 요청 POST
+ * @param myChallengeId
+ * @returns message (성공: '결제 취소 처리되었습니다.')
+ */
+const postRequestRefundApi = (myChallengeId: number) => {
+  return axiosInstance.post(`/payments/${myChallengeId}/cancel`);
+};
+
 export {
   getChallengeGroupApi,
   getReviewsApi,
   getMoreReviewsApi,
   deleteMyChallengeApi,
+  postRequestRefundApi,
 };

--- a/src/lib/axios/challenge/api.ts
+++ b/src/lib/axios/challenge/api.ts
@@ -43,15 +43,6 @@ const getMoreReviewsApi = (pageParam: number, challengeId: number) => {
 };
 
 /**
- * 챌린지 신청 취소 DEL
- * @param challengeId
- * @returns response.data
- */
-const deleteMyChallengeApi = (myChallengeId: number) => {
-  return axiosInstance.delete(`/myChallenges/${myChallengeId}/delete`);
-};
-
-/**
  * 챌린지 신청 취소 환급 요청 POST
  * @param myChallengeId
  * @returns message (성공: '결제 취소 처리되었습니다.')
@@ -64,6 +55,5 @@ export {
   getChallengeGroupApi,
   getReviewsApi,
   getMoreReviewsApi,
-  deleteMyChallengeApi,
   postRequestRefundApi,
 };

--- a/src/lib/axios/challenge/api.ts
+++ b/src/lib/axios/challenge/api.ts
@@ -43,11 +43,11 @@ const getMoreReviewsApi = (pageParam: number, challengeId: number) => {
 };
 
 /**
- * 챌린지 신청 취소 환급 요청 POST
+ * 챌린지 신청 취소 및 환급 요청 POST
  * @param myChallengeId
  * @returns message (성공: '결제 취소 처리되었습니다.')
  */
-const postRequestRefundApi = (myChallengeId: number) => {
+const postCancelParticipantApi = (myChallengeId: number) => {
   return axiosInstance.post(`/payments/${myChallengeId}/cancel`);
 };
 
@@ -55,5 +55,5 @@ export {
   getChallengeGroupApi,
   getReviewsApi,
   getMoreReviewsApi,
-  postRequestRefundApi,
+  postCancelParticipantApi,
 };


### PR DESCRIPTION
close #75 
<!-- PR의 제목은 "[#이슈번호][branch] 이슈이름" 으로 작성해주세요 -->

## ✨ 구현 기능 명세
- 테스트 목적으로 모집 마감 챌린지 챌린지 신청 가능하도록 버튼 활성화
- 챌린지 신청 취소 API 연동

## 🎁 PR Point
- 대기중인 챌린지 환급 요청 API 사용만으로 신청 취소가 함께 동작합니다. (myChallenge 삭제)
- 중간에 구두로 말씀드렸던 것과 같이 쿼리 전달과 동시에 새로고침하는 동작이 원활히 되지 않아 아직 작업 중에 있습니다. 해당 PR 머지 후 이어서 작업 예정 입니다.

## 🕰 소요시간
1d

## 😭 어려웠던 점
뜻하지 않은 서버 불안정으로 인해 테스트를 진행하기 위해 오랜 시간을 사용한 것이지 API 연동 작업의 실질적인 소모 시간은 길지 않았습니다!

<!-- (선택) -->
